### PR TITLE
Turn off caching.

### DIFF
--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -11,7 +11,7 @@ server {
     # Serve up a static page for confirming the server is running
     location / {
         try_files /index.html =404;
-        expires 1y;
+        expires -1;
         add_header Cache-Control "public";
     }
     # Resources for static page


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-578

This doesn't actually disable caching; it just ensures that clients check with the server what the latest version is before deciding whether to use their local cached copy or the newer one.