### PR TITLE
i742 - Allow large file uploads

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -25,6 +25,12 @@ http {
 
     keepalive_timeout  65;
 
+    # this sets the maximum size information to be unlimited; it might
+    # be better to set this to apply only to authenticated endpoints
+    # (once people are authenticated I think we can allow them to send
+    # things of unlimited size).
+    client_max_body_size 0;
+
     #gzip  on;
 
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
this sets the maximum size information to be unlimited; it might
be better to set this to apply only to authenticated endpoints
(once people are authenticated I think we can allow them to send
things of unlimited size).

https://vimc.myjetbrains.com/youtrack/issue/VIMC-742
