### PR TITLE
set proxy timeout values for API

### DIFF
--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -34,6 +34,9 @@ server {
         # proxy_buffering is off, otherwise nginx downloads 
         # the full request before passing it on: This is bad for large files.
         proxy_buffering off;
+
+        proxy_send_timeout 120s;
+        proxy_read_timeout 120s;
     }
 
     location /admin/ {


### PR DESCRIPTION
This seems to work locally with the biggest burden estimates file I have - 117MB