### PR TITLE
i2546: Remove shiny from the montagu proxy

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -31,16 +31,5 @@ http {
     # things of unlimited size).
     client_max_body_size 0;
 
-    #gzip  on;
-
-    # This sets the connection header based on the presence of an upgrade header in the client request
-    # In other words, allows a protocol switch from HTTP/1.1 to WebSocket iff an upgrade header is sent
-    # See /shiny/ block in nginx.montagu.conf for the only case in which this happens
-    # See http://nginx.org/en/docs/http/websocket.html for more info
-    map $http_upgrade $connection_upgrade {
-        default upgrade;
-        ''      close;
-    }
-
     include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -56,32 +56,6 @@ server {
     location /reports/ {
         proxy_pass http://report/;
     }
-
-    # https://support.rstudio.com/hc/en-us/articles/213733868-Running-Shiny-Server-with-a-Proxy
-    location /shiny/ {
-        rewrite ^/shiny/(.*)$ /$1 break;
-
-        proxy_pass http://shiny_proxy;
-        proxy_redirect http://shiny_proxy/ $scheme://$host/shiny/;
-        proxy_http_version 1.1;
-
-        # Here we set the Upgrade and Connection headers to allow a protocol switch from HTTP/1.1 to Websocket
-        # We have to set these explicitly because they are 'hop-by-hop' headers which are not passed
-        # from client to proxied server
-        # See nginx.conf for the setup of $http_upgrade and $http_connection
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-        proxy_read_timeout 20d;
-        proxy_buffering off;
-
-        # These headers are required because we are proxying https to http
-        # Shiny can only run over http
-        proxy_set_header    Host $host;
-        proxy_set_header    X-Real-IP $remote_addr;
-        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header    X-Forwarded-Proto $scheme;
-    }
-
 }
 
 # Redirect all http requests to the SSL endpoint and the correct domain name


### PR DESCRIPTION
This prevents the proxy from forwarding any shiny connections.  It should be merged before the deploy changes