### PR TITLE
add webhook to proxy

### DIFF
--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -81,6 +81,10 @@ server {
     location /reports/ {
         proxy_pass http://report/;
     }
+
+    location /pull-request/ {
+        proxy_pass http://support.montagu.dide.ic.ac.uk:4567/pull-request/;
+    }
 }
 
 # Redirect all http requests to the SSL endpoint and the correct domain name


### PR DESCRIPTION
The webhook is deployed on support with `--restart always` so should always be present when Montagu comes up.