### PR TITLE
fix failing integration test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     image: ${REGISTRY}/orderly-web:mrc-314
     networks:
      - proxy
+    depends_on:
+      - api
     volumes:
      - orderly_volume:/orderly
   db:

--- a/scripts/orderlywebconfig.properties
+++ b/scripts/orderlywebconfig.properties
@@ -1,4 +1,4 @@
 app.url=https://localhost/reports
 auth.fine_grained=false
-montagu.api_url=https://localhost/api/v1
+montagu.api_url=http://api:8080
 montagu.url=https://localhost

--- a/tests/integration_tests/orderly-web.itest.js
+++ b/tests/integration_tests/orderly-web.itest.js
@@ -6,40 +6,41 @@ const browser = TestHelper.getBrowser();
 beforeEach(async () => {
     await TestHelper.ensureLoggedOut(browser);
 });
-
-test('can access orderly web', async () => {
-
-    browser.get("https://localhost/reports/");
-
-    await browser.wait(() => {
-        return browser.getCurrentUrl().then((url) => {
-            return url.indexOf("?redirectTo=") > -1;
-        });
-    });
-
-    const emailField = await browser.findElement(webDriver.By.id("email-input"));
-    const pwField = await browser.findElement(webDriver.By.id("password-input"));
-
-    await emailField.sendKeys("test.user@example.com");
-    await pwField.sendKeys("password");
-
-    await browser.findElement(webDriver.By.id("login-button"))
-        .click();
-
-    await browser.wait(() => {
-        return browser.getCurrentUrl().then((url) => {
-            return url.indexOf("https://localhost/reports") > -1;
-        });
-    });
-
-    const title = await browser.findElement(webDriver.By.className("site-title"));
-    expect(await title.getText()).toBe("Reporting portal")
-});
+//
+// test('can access orderly web', async () => {
+//
+//     browser.get("https://localhost/reports/");
+//
+//     await browser.wait(() => {
+//         return browser.getCurrentUrl().then((url) => {
+//             return url.indexOf("?redirectTo=") > -1;
+//         });
+//     });
+//
+//     const emailField = await browser.findElement(webDriver.By.id("email-input"));
+//     const pwField = await browser.findElement(webDriver.By.id("password-input"));
+//
+//     await emailField.sendKeys("test.user@example.com");
+//     await pwField.sendKeys("password");
+//
+//     await browser.findElement(webDriver.By.id("login-button"))
+//         .click();
+//
+//     await browser.wait(() => {
+//         return browser.getCurrentUrl().then((url) => {
+//             return url.indexOf("https://localhost/reports") > -1;
+//         });
+//     });
+//
+//     const title = await browser.findElement(webDriver.By.className("site-title"));
+//     expect(await title.getText()).toBe("Reporting portal")
+// });
 
 test('old report page urls are redirected', async () => {
 
     browser.get("https://localhost/reports/r1/20170516-134824-a16bab9d");
 
+    TestHelper.ensureLoggedIn(browser);
     await browser.wait(() => {
         return browser.getCurrentUrl().then((url) => {
             return url === "https://localhost/reports/report/r1/20170516-134824-a16bab9d";

--- a/tests/integration_tests/orderly-web.itest.js
+++ b/tests/integration_tests/orderly-web.itest.js
@@ -6,35 +6,35 @@ const browser = TestHelper.getBrowser();
 beforeEach(async () => {
     await TestHelper.ensureLoggedOut(browser);
 });
-//
-// test('can access orderly web', async () => {
-//
-//     browser.get("https://localhost/reports/");
-//
-//     await browser.wait(() => {
-//         return browser.getCurrentUrl().then((url) => {
-//             return url.indexOf("?redirectTo=") > -1;
-//         });
-//     });
-//
-//     const emailField = await browser.findElement(webDriver.By.id("email-input"));
-//     const pwField = await browser.findElement(webDriver.By.id("password-input"));
-//
-//     await emailField.sendKeys("test.user@example.com");
-//     await pwField.sendKeys("password");
-//
-//     await browser.findElement(webDriver.By.id("login-button"))
-//         .click();
-//
-//     await browser.wait(() => {
-//         return browser.getCurrentUrl().then((url) => {
-//             return url.indexOf("https://localhost/reports") > -1;
-//         });
-//     });
-//
-//     const title = await browser.findElement(webDriver.By.className("site-title"));
-//     expect(await title.getText()).toBe("Reporting portal")
-// });
+
+test('can access orderly web', async () => {
+
+    browser.get("https://localhost/reports/");
+
+    await browser.wait(() => {
+        return browser.getCurrentUrl().then((url) => {
+            return url.indexOf("?redirectTo=") > -1;
+        });
+    });
+
+    const emailField = await browser.findElement(webDriver.By.id("email-input"));
+    const pwField = await browser.findElement(webDriver.By.id("password-input"));
+
+    await emailField.sendKeys("test.user@example.com");
+    await pwField.sendKeys("password");
+
+    await browser.findElement(webDriver.By.id("login-button"))
+        .click();
+
+    await browser.wait(() => {
+        return browser.getCurrentUrl().then((url) => {
+            return url.indexOf("https://localhost/reports") > -1;
+        });
+    });
+
+    const title = await browser.findElement(webDriver.By.className("site-title"));
+    expect(await title.getText()).toBe("Reporting portal")
+});
 
 test('old report page urls are redirected', async () => {
 


### PR DESCRIPTION
This test was dependent on the new `/report/<name>/<version>` route not actually being wired up. Since it now is wired up, it is login protected so we have to log in to confirm that it works.