### PR TITLE
use variables for proxy pass

### DIFF
--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -71,15 +71,17 @@ server {
         proxy_pass http://contrib/;
     }
     location /reports/ {
-        proxy_pass http://orderly_web_web:8888/;
-        proxy_redirect default;
+        set $orderly_web http://orderly_web_web:8888/;
+        proxy_pass $orderly_web;
+        proxy_redirect $orderly_web /reports/;
 
         location "~/reports/(?<name>[^/]+)/(?<version>\d{8}-\d{6}-[0-9a-f]{8})" {
             return 301 /reports/report/$name/$version;
         }
     }
     location /pull-request/ {
-        proxy_pass http://support.montagu.dide.ic.ac.uk:4567/pull-request/;
+        set $webhook http://support.montagu.dide.ic.ac.uk:4567/pull-request/;
+        proxy_pass $webhook;
     }
 
 }


### PR DESCRIPTION
Turns out using variables in `proxy_pass` just bypasses nginx's "fall over if upstream doesn't exist" behaviour.