### PR TITLE
mrc-288

### DIFF
--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -70,10 +70,13 @@ server {
     location /contribution/ {
         proxy_pass http://contrib/;
     }
+
+    set $orderly_web http://orderly_web_web:8888;
     location /reports/ {
-        set $orderly_web http://orderly_web_web:8888/;
+        resolver 127.0.0.11 valid=30s;
+        rewrite ^/reports/(.*) /$1 break;
         proxy_pass $orderly_web;
-        proxy_redirect $orderly_web /reports/;
+        proxy_redirect http://orderly_web_web:8888/ /reports/;
 
         location "~/reports/(?<name>[^/]+)/(?<version>\d{8}-\d{6}-[0-9a-f]{8})" {
             return 301 /reports/report/$name/$version;

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -71,15 +71,17 @@ server {
         proxy_pass http://contrib/;
     }
     location /reports/ {
-        proxy_pass http://orderly_web_web:8888/;
-        proxy_redirect default;
+        set $orderly_web http://orderly_web_web:8888/;
+        proxy_pass $orderly_web;
+        proxy_redirect $orderly_web /reports/;
 
         location "~/reports/(?<name>[^/]+)/(?<version>\d{8}-\d{6}-[0-9a-f]{8})" {
             return 301 /reports/report/$name/$version;
         }
     }
     location /pull-request/ {
-        proxy_pass http://support.montagu.dide.ic.ac.uk:4567/pull-request/;
+        set $webhook http://support.montagu.dide.ic.ac.uk:4567/pull-request/;
+        proxy_pass $webhook;
     }
 
 }

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -71,9 +71,9 @@ server {
         proxy_pass http://contrib/;
     }
 
-    resolver 127.0.0.11 valid=30s;
     set $orderly_web http://orderly_web_web:8888;
     location /reports/ {
+        resolver 127.0.0.11 valid=30s;
         rewrite ^/reports/(.*) /$1 break;
         proxy_pass $orderly_web;
         proxy_redirect http://orderly_web_web:8888/ /reports/;
@@ -83,6 +83,7 @@ server {
         }
     }
     location /pull-request/ {
+        resolver 127.0.0.11 valid=30s;
         set $webhook http://support.montagu.dide.ic.ac.uk:4567/pull-request/;
         proxy_pass $webhook;
     }

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -71,6 +71,8 @@ server {
         proxy_pass http://contrib/;
     }
 
+    # resolving /reports/ dynamically because the orderly web container may not be up when the proxy starts
+    # for an explanation of this config see: https://tenzer.dk/nginx-with-dynamic-upstreams/
     set $orderly_web http://orderly_web_web:8888;
     location /reports/ {
         resolver 127.0.0.11 valid=30s;

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -71,9 +71,9 @@ server {
         proxy_pass http://contrib/;
     }
 
+    resolver 127.0.0.11 valid=30s;
     set $orderly_web http://orderly_web_web:8888;
     location /reports/ {
-        resolver 127.0.0.11 valid=30s;
         rewrite ^/reports/(.*) /$1 break;
         proxy_pass $orderly_web;
         proxy_redirect http://orderly_web_web:8888/ /reports/;


### PR DESCRIPTION
So you can get around nginx needing the upstream to be present on start by resolving routes dynamically using a variable for the upstream server. This feels a bit hack-y to me as our upstream isn't really variable, it's just not always up. But it seems like a popular solution. Worked out the config based on this SO thread https://stackoverflow.com/questions/32845674/setup-nginx-not-to-crash-if-host-in-upstream-is-not-found and this blog post https://tenzer.dk/nginx-with-dynamic-upstreams/