### PR TITLE
VIMC-3345 redirect logged in users if requested

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Vaccine Impact Modelling Consortium - Montagu</title>
-    <link rel="stylesheet" href="resources/css/third_party/bootstrap.min.css" />
-    <link rel="stylesheet" href="resources/css/montagu.css" />
+    <link rel="stylesheet" href="resources/css/third_party/bootstrap.min.css"/>
+    <link rel="stylesheet" href="resources/css/montagu.css"/>
 
     <script src="resources/js/third_party/jquery.min.js"></script>
     <script src="resources/js/third_party/jwt-decode.min.js"></script>
@@ -21,10 +21,11 @@
 <div id="app">
     <header class="header">
         <a href="https://vaccineimpact.org">
-                <img class="pl-md-1 logo" src="./resources/logo.png" alt="Vaccine Impact Modelling Consortium" />
+            <img class="pl-md-1 logo" src="./resources/logo.png" alt="Vaccine Impact Modelling Consortium"/>
         </a>
         <div class="siteTitle">Montagu</div>
-        <montagu-login-status v-bind:username="username" v-on:logout="logout" class="login-status"></montagu-login-status>
+        <montagu-login-status v-bind:username="username" v-on:logout="logout"
+                              class="login-status"></montagu-login-status>
     </header>
     <div id="content" class="container mt-3">
         <p>
@@ -41,7 +42,7 @@
         </p>
         <montagu-login-form v-bind:username="username" v-bind:login-error="loginError"
                             v-bind:redirect-message="redirectMessage"
-                              v-on:login="login" class="login-form"></montagu-login-form>
+                            v-on:login="login" class="login-form"></montagu-login-form>
         <div class="portals">
             <h1>Portals</h1>
             <table>
@@ -85,11 +86,10 @@
     const utils = MontaguUtils;
     const auth = new MontaguAuth(utils.getApiRoot());
     const logic = new MontaguLogin(
-                        auth,
-                        window.localStorage,
-                        jwt_decode,
-                        pako
-                );
+        auth,
+        jwt_decode,
+        pako
+    );
 
 
     new Vue({
@@ -100,23 +100,33 @@
             redirectMessage: ""
         },
         methods: {
-            initialise: function() {
+            initialise: function () {
                 const data = this;
                 logic.getUserName().then((result) => {
-                  data.username = result
-              })
+                    data.username = result;
+
+                    const redirectLocation = utils.paramFromQueryString(location.search, "redirectTo");
+                    if (result && redirectLocation) {
+                        data.redirectMessage = `Redirecting you back to ${redirectLocation}.
+                            If you are not automatically redirected in a few seconds please click <a href="${redirectLocation}">here</a>`;
+                        window.location.href = redirectLocation
+                    }
+                })
             },
-            logout: function() {
+            logout: function () {
                 const data = this;
                 logic.logout().then(
                     () => {
                         data.username = '';
                         data.loginError = '';
                     },
-                    (error) => { data.username = ''; data.loginError = error }
+                    (error) => {
+                        data.username = '';
+                        data.loginError = error
+                    }
                 );
             },
-            login: function(email, password) {
+            login: function (email, password) {
                 const data = this;
                 logic.login(email, password).then(
                     (result) => {
@@ -126,10 +136,13 @@
                         if (redirectLocation) {
                             data.redirectMessage = `Redirecting you back to ${redirectLocation}.
                             If you are not automatically redirected in a few seconds please click <a href="${redirectLocation}">here</a>`;
-                            window.location.href=redirectLocation
+                            window.location.href = redirectLocation
                         }
                     },
-                    (error) => { data.username = ''; data.loginError = error; }
+                    (error) => {
+                        data.username = '';
+                        data.loginError = error;
+                    }
                 );
             }
         },

--- a/resources/js/montagu-login.js
+++ b/resources/js/montagu-login.js
@@ -2,7 +2,6 @@
 class MontaguLogin {
 
     constructor(montaguAuth, jwt_decode, pako) {
-        this.TOKEN_KEY = "accessToken";
         this.montaguAuth = montaguAuth;
         this.jwt_decode = jwt_decode;
         this.pako = pako;

--- a/resources/js/montagu-login.js
+++ b/resources/js/montagu-login.js
@@ -1,10 +1,9 @@
 //Logic class for logging in and out of Montagu
 class MontaguLogin {
 
-    constructor(montaguAuth, localStorage, jwt_decode, pako) {
+    constructor(montaguAuth, jwt_decode, pako) {
         this.TOKEN_KEY = "accessToken";
         this.montaguAuth = montaguAuth;
-        this.localStorage = localStorage;
         this.jwt_decode = jwt_decode;
         this.pako = pako;
     }
@@ -28,10 +27,6 @@ class MontaguLogin {
         return expiry > now
     }
 
-    writeTokenToLocalStorage(token) {
-        this.localStorage.setItem(this.TOKEN_KEY, token);
-    }
-
     login(email, password) {
         return this.montaguAuth.login(email, password)
             .then((data) => this.montaguLoginSuccess(data))
@@ -46,20 +41,13 @@ class MontaguLogin {
         return this.montaguAuth.setCookies(token).then(
             () => {
                 const decodedToken = this.decodeToken(token);
-                const montaguUserName = decodedToken.sub;
-
-                // TODO remove once local storage deprecated in portals
-                // https://vimc.myjetbrains.com/youtrack/issue/VIMC-2865
-                this.writeTokenToLocalStorage(token);
-                return montaguUserName
+                return decodedToken.sub;
             }
         );
     }
 
     logout() {
-        // TODO remove once local storage deprecated in portals
-        // https://vimc.myjetbrains.com/youtrack/issue/VIMC-2865
-        this.writeTokenToLocalStorage('');
+
         return this.montaguAuth.logout()
             .catch((jqXHR) => {
                 throw MontaguLogin.montaguApiError(jqXHR)

--- a/resources/new-password.html
+++ b/resources/new-password.html
@@ -35,9 +35,8 @@
         data: {
             utils: MontaguUtils,
             passwordApi: new MontaguPassword(MontaguUtils.getApiRoot()),
-            loginLogic: new MontaguLogin(null, null,jwt_decode,pako)
+            loginLogic: new MontaguLogin(null, jwt_decode,pako)
         },
     });
 </script>
-</html>
 </html>

--- a/tests/integration_tests/login.itest.js
+++ b/tests/integration_tests/login.itest.js
@@ -90,3 +90,21 @@ test('can login with redirect', async () => {
 
     expect(await browser.getCurrentUrl()).toBe("http://nonsense/");
 });
+
+test('redirects user if redirect query is present and user is already logged in', async () => {
+
+    await TestHelper.ensureLoggedIn(browser);
+
+    // navigate away
+    browser.get("https://google.com");
+
+    //navigate back
+    browser.get("https://localhost?redirectTo=http://nonsense");
+
+    await browser.wait(() => {
+        return browser.getCurrentUrl().then((url) => {
+            return url === "http://nonsense/";
+        });
+    });
+
+}, 9000);

--- a/tests/montagu-login.test.js
+++ b/tests/montagu-login.test.js
@@ -17,7 +17,7 @@ test('can decode jwt token', () => {
     const mockInflate = jest.fn(x => x + "inflated");
     const mockDecode = jest.fn(x => x + "decoded");
 
-    const sut = new MontaguLogin(null, null, mockDecode, {inflate: mockInflate});
+    const sut = new MontaguLogin(null, mockDecode, {inflate: mockInflate});
     const result = sut.decodeToken(toDecode);
 
     const expected = atob("test/+") + "inflateddecoded";
@@ -69,7 +69,6 @@ test('user name is empty if getUserDetails fails', (done) => {
 test('can login', (done) => {
     const encodedToken = getEncodedToken("test user name", new Date(now.getTime() + (60 * 60 * 1000)));
 
-    const mockSetItem = jest.fn();
     const mockInflate = jest.fn(x => x);
     const mockDecode = jest.fn(x => JSON.parse(x));
     const mockLogin = jest.fn(x => new Promise((resolve, reject) => {
@@ -95,10 +94,6 @@ test('can login', (done) => {
 
             expect(mockLogin.mock.calls.length).toBe(1);
             expect(mockSetCookies.mock.calls.length).toBe(1);
-
-            expect(mockSetItem.mock.calls.length).toBe(1);
-            expect(mockSetItem.mock.calls[0][0]).toBe("accessToken");
-            expect(mockSetItem.mock.calls[0][1]).toBe(encodedToken);
             done();
         },
         (error) => {

--- a/tests/montagu-login.test.js
+++ b/tests/montagu-login.test.js
@@ -12,17 +12,6 @@ test('can create MontaguLogin', () => {
     const sut = new MontaguLogin();
 });
 
-test('can write token to local storage', () => {
-    const mockSetItem = jest.fn();
-    const sut = new MontaguLogin(null, {setItem: mockSetItem});
-
-    sut.writeTokenToLocalStorage("testtoken");
-
-    expect(mockSetItem.mock.calls.length).toBe(1);
-    expect(mockSetItem.mock.calls[0][0]).toBe("accessToken");
-    expect(mockSetItem.mock.calls[0][1]).toBe("testtoken");
-});
-
 test('can decode jwt token', () => {
     const toDecode = "test_-";
     const mockInflate = jest.fn(x => x + "inflated");
@@ -91,7 +80,6 @@ test('can login', (done) => {
     }));
 
     const sut = new MontaguLogin({login: mockLogin, setCookies: mockSetCookies}, //mock auth
-        {setItem: mockSetItem}, //mock local storage
         mockDecode, //mock jwt_decode
         {inflate: mockInflate} //mock pako
     );
@@ -122,7 +110,6 @@ test('can login', (done) => {
 
 test('returns error message when authentication fails', (done) => {
 
-    const mockSetItem = jest.fn();
     const mockInflate = jest.fn();
     const mockDecode = jest.fn();
     const mockLogin = jest.fn(x => new Promise((resolve, reject) => {
@@ -133,7 +120,6 @@ test('returns error message when authentication fails', (done) => {
     }));
 
     const sut = new MontaguLogin({login: mockLogin, setCookies: mockSetCookies}, //mock auth
-        {setItem: mockSetItem}, //mock local storage
         mockDecode, //mock jwt_decode
         {inflate: mockInflate} //mock pako
     );
@@ -154,8 +140,6 @@ test('returns error message when authentication fails', (done) => {
             expect(mockLogin.mock.calls.length).toBe(1);
             expect(mockSetCookies.mock.calls.length).toBe(0);
 
-            expect(mockSetItem.mock.calls.length).toBe(0);
-
             done();
         }
     );
@@ -166,7 +150,6 @@ test('returns error message when setCookies fails', (done) => {
 
     const encodedToken = getEncodedToken("test user name", new Date(now.getTime() + (60 * 60 * 1000)));
 
-    const mockSetItem = jest.fn();
     const mockInflate = jest.fn(x => x);
     const mockDecode = jest.fn(x => JSON.parse(x));
     const mockLogin = jest.fn(x => new Promise((resolve, reject) => {
@@ -177,7 +160,6 @@ test('returns error message when setCookies fails', (done) => {
     }));
 
     const sut = new MontaguLogin({login: mockLogin, setCookies: mockSetCookies}, //mock auth
-        {setItem: mockSetItem}, //mock local storage
         mockDecode, //mock jwt_decode
         {inflate: mockInflate} //mock pako
     );
@@ -198,8 +180,6 @@ test('returns error message when setCookies fails', (done) => {
             expect(mockLogin.mock.calls.length).toBe(1);
             expect(mockSetCookies.mock.calls.length).toBe(1);
 
-            expect(mockSetItem.mock.calls.length).toBe(0);
-
             done();
         }
     );
@@ -207,14 +187,12 @@ test('returns error message when setCookies fails', (done) => {
 });
 
 test('can logout', (done) => {
-    const mockSetItem = jest.fn();
 
     const mockLogout = jest.fn(x => new Promise((resolve, reject) => {
         resolve();
     }));
 
     const sut = new MontaguLogin({logout: mockLogout}, //mock auth
-        {setItem: mockSetItem} //mock local storage
     );
 
     //This returns a promise - invoking the promise will call auth login methods via further promises, here mocked to
@@ -223,11 +201,6 @@ test('can logout', (done) => {
         () => {
             //Expected mocks were called
             expect(mockLogout.mock.calls.length).toBe(1);
-
-            //expect empty token written to local storage
-            expect(mockSetItem.mock.calls.length).toBe(1);
-            expect(mockSetItem.mock.calls[0][0]).toBe("accessToken");
-            expect(mockSetItem.mock.calls[0][1]).toBe('');
             done();
         },
         (error) => {


### PR DESCRIPTION
This is a workaround for the fact that links from pdfs don't seem to send all the cookie headers; see comments here: https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-3345

I could dig further into the above - it looks like cookies marked with the domain `vaccinempact.org` are being sent, but not those with `montagu.vaccineimpact.org`, so possibly changing that is the answer. But in any case this change seems like reasonable behaviour - if for some reason you visit 
`montagu.vaccineimpact.org?redirectTo=something.com` and you're already logged in, just redirect the user directly.

While I was at it I removed the obsolete local storage logic.