### PR TITLE
vimc-4204 Updated path for partners data viz tool

### DIFF
--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -41,7 +41,7 @@ server {
     # Private data visualisation app - authenticated with Montagu via OrderlyWeb, redirects to the report on OW
     rewrite /2020/visualization-partners /2020/visualisation-partners last;
     location /2020/visualisation-partners {
-        return 301 /reports/report/internal-2018-interactive-plotting/version/20191114-152933-6918620a/artefacts/index.html?inline=true;
+        return 301 /reports/report/internal-2018-interactive-plotting/20200727-142228-bf75fe24/artefacts/index.html?inline=true;
     }
 
     # Public data visualisation app, not authenticated - report data will be copied to this location

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -41,7 +41,7 @@ server {
     # Private data visualisation app - authenticated with Montagu via OrderlyWeb, redirects to the report on OW
     rewrite /2020/visualization-partners /2020/visualisation-partners last;
     location /2020/visualisation-partners {
-        return 301 /reports/report/internal-2018-interactive-plotting/20200727-142228-bf75fe24/artefacts/index.html?inline=true;
+        return 301 /reports/report/internal-2018-interactive-plotting/version/20200727-142228-bf75fe24/artefacts/index.html?inline=true;
     }
 
     # Public data visualisation app, not authenticated - report data will be copied to this location


### PR DESCRIPTION
Following discussion with Kim and Katy, we are just going to use existing paper data for the private (partners) data vis tool for now. 

This branch is installed on uat, so this link should work:
https://support.montagu.dide.ic.ac.uk:10443/2020/visualisation-partners