### PR TITLE
vimc-4320 use montagu-static image from dockerhub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     depends_on:
      - api
   static:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-static:master
+    image: ${ORG}/montagu-static:master
     networks:
      - proxy
     volumes:


### PR DESCRIPTION
See https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-4230 for discussion of the building of the static sever image itself