### PR TITLE
vimc-4292 remove all refs to private docker registry

### DIFF
--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -3,5 +3,5 @@
 here=$(dirname $0)
 
 # Use this once you have run the API with ./run-dependencies.sh
-image=docker.montagu.dide.ic.ac.uk:5000/montagu-cli:master
+image=vimc/montagu-cli:master
 exec docker run --network $NETWORK $image "$@"

--- a/scripts/install-chromedriver.sh
+++ b/scripts/install-chromedriver.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
 
-wget https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip
+wget https://chromedriver.storage.googleapis.com/85.0.4183.87/chromedriver_linux64.zip
 unzip chromedriver_linux64.zip
 sudo mv chromedriver /usr/bin/chromedriver
 sudo chown root:root /usr/bin/chromedriver

--- a/shared-build-env.dockerfile
+++ b/shared-build-env.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.montagu.dide.ic.ac.uk:5000/node-docker:master
+FROM vimc/node-docker:master
 
 ARG MONTAGU_GIT_ID="UNKNOWN"
 ARG MONTAGU_GIT_BRANCH="UNKNOWN"


### PR DESCRIPTION
Had to also update chromedriver, which had become out of date since the last build.

Other PRs:
https://github.com/vimc/montagu-api/pull/434
https://github.com/vimc/montagu-webapps/pull/438