### PR TITLE
vimc-4180 Added 404 error page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Vaccine Impact Modelling Consortium - Page not found</title>
+    <link rel="stylesheet" href="resources/css/third_party/bootstrap.min.css" />
+    <link rel="stylesheet" href="resources/css/montagu.css"/>
+</head>
+<body>
+<header class="header">
+    <a href="https://vaccineimpact.org">
+        <img class="pl-md-1 logo" src="resources/logo.png" alt="Vaccine Impact Modelling Consortium" />
+    </a>
+    <div class="siteTitle">Montagu</div>
+</header>
+<div id="content"  class="container">
+    <h1 class="header-small">Page not found</h1>
+    Sorry, that page was not found. <a href="/">Go to homepage.</a>
+</div>
+</body>
+</html>

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM nginx:stable
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.montagu.conf /etc/nginx/conf.d/montagu.conf.template
 COPY index.html /usr/share/nginx/html/index.html
+COPY 404.html /usr/share/nginx/html/404.html
 COPY resources /usr/share/nginx/html/resources
 
 # Copy third party javascript from npm modules

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -3,6 +3,7 @@ FROM nginx:1.15
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.montagu.conf /etc/nginx/conf.d/montagu.conf
 COPY index.html /usr/share/nginx/html/index.html
+COPY 404.html /usr/share/nginx/html/404.html
 COPY resources /usr/share/nginx/html/resources
 
 # Copy third party javascript from npm modules

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -15,8 +15,10 @@ server {
 
     root /usr/share/nginx/html;
 
+    error_page 404 /404.html;
+
     # Serve up a static page for confirming the server is running
-    location / {
+    location = / {
         try_files /index.html =404;
         expires -1;
         add_header Cache-Control "public";

--- a/scripts/install-chromedriver.sh
+++ b/scripts/install-chromedriver.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
 
-wget https://chromedriver.storage.googleapis.com/85.0.4183.87/chromedriver_linux64.zip
+wget https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_linux64.zip
 unzip chromedriver_linux64.zip
 sudo mv chromedriver /usr/bin/chromedriver
 sudo chown root:root /usr/bin/chromedriver

--- a/scripts/install-chromedriver.sh
+++ b/scripts/install-chromedriver.sh
@@ -8,5 +8,3 @@ unzip chromedriver_linux64.zip
 sudo mv chromedriver /usr/bin/chromedriver
 sudo chown root:root /usr/bin/chromedriver
 sudo chmod +x /usr/bin/chromedriver
-
-

--- a/scripts/install-chromedriver.sh
+++ b/scripts/install-chromedriver.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -ex
 
 sudo apt-get update
 sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
@@ -10,6 +9,4 @@ sudo mv chromedriver /usr/bin/chromedriver
 sudo chown root:root /usr/bin/chromedriver
 sudo chmod +x /usr/bin/chromedriver
 
-# just for diagnostics
-echo $(google-chrome --version)
 

--- a/scripts/install-chromedriver.sh
+++ b/scripts/install-chromedriver.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -ex
 
 sudo apt-get update
 sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
@@ -8,3 +9,7 @@ unzip chromedriver_linux64.zip
 sudo mv chromedriver /usr/bin/chromedriver
 sudo chown root:root /usr/bin/chromedriver
 sudo chmod +x /usr/bin/chromedriver
+
+# just for diagnostics
+echo $(google-chrome --version)
+

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -24,12 +24,14 @@ docker run --rm \
     $ORG/montagu-cert-tool:master \
     gen-self-signed /workspace > /dev/null 2> /dev/null
 
+echo "Running reverse proxy"
 docker run -d \
 	-p "443:443" -p "80:80" \
 	--name reverse-proxy \
 	--network montagu_proxy\
 	$SHA_TAG 443 localhost
 
+echo "Running metrics"
 docker run -d \
     -p "9113:9113" \
     --network montagu_proxy \
@@ -41,6 +43,7 @@ docker run -d \
 # the real dhparam will be 4096 bits but that takes ages to generate
 openssl dhparam -out workspace/dhparam.pem 1024
 
+echo "Copying workshpace"
 docker cp workspace/certificate.pem reverse-proxy:/etc/montagu/proxy/
 docker cp workspace/ssl_key.pem reverse-proxy:/etc/montagu/proxy/
 docker cp workspace/dhparam.pem reverse-proxy:/etc/montagu/proxy/
@@ -48,6 +51,7 @@ rm -rf workspace
 
 sleep 2s
 
+echo "Running integration tests container"
 docker run \
   --rm \
 	--network host \

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -24,14 +24,12 @@ docker run --rm \
     $ORG/montagu-cert-tool:master \
     gen-self-signed /workspace > /dev/null 2> /dev/null
 
-echo "Running reverse proxy"
 docker run -d \
 	-p "443:443" -p "80:80" \
 	--name reverse-proxy \
 	--network montagu_proxy\
 	$SHA_TAG 443 localhost
 
-echo "Running metrics"
 docker run -d \
     -p "9113:9113" \
     --network montagu_proxy \
@@ -43,7 +41,6 @@ docker run -d \
 # the real dhparam will be 4096 bits but that takes ages to generate
 openssl dhparam -out workspace/dhparam.pem 1024
 
-echo "Copying workshpace"
 docker cp workspace/certificate.pem reverse-proxy:/etc/montagu/proxy/
 docker cp workspace/ssl_key.pem reverse-proxy:/etc/montagu/proxy/
 docker cp workspace/dhparam.pem reverse-proxy:/etc/montagu/proxy/
@@ -51,7 +48,6 @@ rm -rf workspace
 
 sleep 2s
 
-echo "Running integration test container"
 docker run \
   --rm \
 	--network host \

--- a/tests/integration_tests/404-page.itest.js
+++ b/tests/integration_tests/404-page.itest.js
@@ -1,0 +1,39 @@
+const webDriver = require("selenium-webdriver");
+const TestHelper = require('./test-helper.js');
+
+const browser = TestHelper.getBrowser();
+
+beforeEach(async () => {
+    await TestHelper.ensureLoggedOut(browser);
+});
+
+test('Shows 404 page for unknown urls', async () => {
+    await TestHelper.ensureLoggedIn(browser);
+
+    browser.get("https://localhost/blah");
+    await browser.wait(() => {
+        return browser.getCurrentUrl().then((url) => {
+            return url === "https://localhost/blah";
+        });
+    });
+    const header = browser.findElement(webDriver.By.css("#content h1"));
+    expect(await header.getText()).toBe("Page not found");
+
+});
+
+test('Link in 404 page returns to index', async () => {
+
+    browser.get("http://localhost/blah");
+    await browser.wait(() => {
+        return browser.getCurrentUrl().then((url) => {
+            return url === "https://localhost/blah";
+        });
+    });
+    const link = browser.findElement(webDriver.By.css("#content a"));
+    link.click();
+    await browser.wait(() => {
+        return browser.getCurrentUrl().then((url) => {
+            return url === "https://localhost/";
+        });
+    });
+});

--- a/tests/integration_tests/login.itest.js
+++ b/tests/integration_tests/login.itest.js
@@ -112,13 +112,31 @@ test('redirects user if redirect query is present and user is already logged in'
 test('Shows 404 page for unknown urls', async () => {
     await TestHelper.ensureLoggedIn(browser);
 
-    browser.get("https://google.com");
+    browser.get("https://localhost/blah");
     await browser.wait(() => {
         return browser.getCurrentUrl().then((url) => {
-            return url === "http://localhost/blah";
+            return url === "https://localhost/blah/";
         });
     });
     const header = browser.findElement(webDriver.By.css("h1"));
     expect(header.getText()).toBe("Page not found");
+
+});
+
+test('Link in 404 page returns to index', async () => {
+
+    browser.get("http://localhost/blah");
+    await browser.wait(() => {
+        return browser.getCurrentUrl().then((url) => {
+            return url === "https://localhost/blah";
+        });
+    });
+    const link = browser.findElement(webDriver.By.css("a"));
+    link.click();
+    await browser.wait(() => {
+        return browser.getCurrentUrl().then((url) => {
+            return url === "https://localhost/";
+        });
+    });
 
 });

--- a/tests/integration_tests/login.itest.js
+++ b/tests/integration_tests/login.itest.js
@@ -108,3 +108,17 @@ test('redirects user if redirect query is present and user is already logged in'
     });
 
 }, 9000);
+
+test('Shows 404 page for unknown urls', async () => {
+    await TestHelper.ensureLoggedIn(browser);
+
+    browser.get("https://google.com");
+    await browser.wait(() => {
+        return browser.getCurrentUrl().then((url) => {
+            return url === "http://localhost/blah";
+        });
+    });
+    const header = browser.findElement(webDriver.By.css("h1"));
+    expect(header.getText()).toBe("Page not found");
+
+});

--- a/tests/integration_tests/login.itest.js
+++ b/tests/integration_tests/login.itest.js
@@ -105,34 +105,3 @@ test('redirects user if redirect query is present and user is already logged in'
     }, 2000);
 }, 9000);
 
-test('Shows 404 page for unknown urls', async () => {
-    await TestHelper.ensureLoggedIn(browser);
-
-    browser.get("https://localhost/blah");
-    await browser.wait(() => {
-        return browser.getCurrentUrl().then((url) => {
-            return url === "https://localhost/blah/";
-        });
-    });
-    const header = browser.findElement(webDriver.By.css("h1"));
-    expect(header.getText()).toBe("Page not found");
-
-});
-
-test('Link in 404 page returns to index', async () => {
-
-    browser.get("http://localhost/blah");
-    await browser.wait(() => {
-        return browser.getCurrentUrl().then((url) => {
-            return url === "https://localhost/blah";
-        });
-    });
-    const link = browser.findElement(webDriver.By.css("a"));
-    link.click();
-    await browser.wait(() => {
-        return browser.getCurrentUrl().then((url) => {
-            return url === "https://localhost/";
-        });
-    });
-
-});


### PR DESCRIPTION
Stopped nginx config from matching the index page for all urls, and added a 'Page not found' page to show instead. 

Had to update a couple of integration tests which were failing on master, when redirecting to nonsense urls. Using a timeout rather than waiting for the url to be the browser's current one seemed to work, but the nonsense url also seemed to get mangeld when navigating from google, so I used a real url for that test instead. I guess chromdriver's behaviour must have changed?