### PR TITLE
vimc-4437 Provide "datavis" routes, and make regexes more strict

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <title>Vaccine Impact Modelling Consortium - Page not found</title>
-    <link rel="stylesheet" href="resources/css/third_party/bootstrap.min.css" />
-    <link rel="stylesheet" href="resources/css/montagu.css"/>
+    <link rel="stylesheet" href="/resources/css/third_party/bootstrap.min.css" />
+    <link rel="stylesheet" href="/resources/css/montagu.css"/>
 </head>
 <body>
 <header class="header">
     <a href="https://vaccineimpact.org">
-        <img class="pl-md-1 logo" src="resources/logo.png" alt="Vaccine Impact Modelling Consortium" />
+        <img class="pl-md-1 logo" src="/resources/logo.png" alt="Vaccine Impact Modelling Consortium" />
     </a>
     <div class="siteTitle">Montagu</div>
 </header>

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -41,13 +41,13 @@ server {
     }
 
     # Private data visualisation app - authenticated with Montagu via OrderlyWeb, redirects to the report on OW
-    rewrite /2020/visualization-partners /2020/visualisation-partners last;
+    rewrite ^/2020/(visualization|datavis)-partners/?$ /2020/visualisation-partners last;
     location /2020/visualisation-partners {
         return 301 /reports/report/internal-2018-interactive-plotting/version/20200727-142228-bf75fe24/artefacts/index.html?inline=true;
     }
 
     # Public data visualisation app, not authenticated - report data will be copied to this location
-    rewrite /2020/visualization /2020/visualisation last;
+    rewrite ^/2020/(visualization|datavis)/?$ /2020/visualisation last;
     location /2020/visualisation/ {
     }
 


### PR DESCRIPTION
This adds available routes:
 - /2020/datavis - which redirects to the public datavis tool (local on 2020/visualisation)
 - /2020/datavis-partners - which redirects to the funders datavis tool (a particular version of report on OW - authentication required)

I also tightened up the regexes so that e.g. /2020/datavis-someothernonses gets a 404 rather than the public tool. 

You can run this locally - will see a default Hello world for the 'public tool' and a report not found error for the funders tool. But I've also put it on UAT, so that you can test how it should really look: 
https://support.montagu.dide.ic.ac.uk:10443/2020/datavis
https://support.montagu.dide.ic.ac.uk:10443/2020/datavis-partners
