### PR TITLE
Fix proxy location of naomi bot

### DIFF
--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -142,7 +142,7 @@ server {
     # Resolving dynamically for the same reason as above
     location /naomi-bot/ {
         resolver 127.0.0.11 valid=30s;
-        set $webhook http://support.montagu.dide.ic.ac.uk:4568/naomi-bot/;
+        set $webhook http://wpia-bots.dide.ic.ac.uk:4568/naomi-bot/;
         proxy_pass $webhook;
     }
 }


### PR DESCRIPTION
I've moved the naomi PR bot onto wpia-bots VM. This PR updates the proxy configuration to point to the new location