### PR TITLE
Remove public cache-controls (fixes settings override, and perhaps shouldn't be there anyway)

### DIFF
--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -42,22 +42,44 @@ server {
     error_page 404 /404.html;
 
     # Serve up a static page for confirming the server is running
+    # Note that the add_header Cache-Control causes all other add_headers to be forgotten,
+    # so need to paste the top-level ones again in this, and later location sections that
+    # declare the Cache-Control header. (See VIMC-7074)
+
     location = / {
         try_files /index.html =404;
         expires -1;
         add_header Cache-Control "public";
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Content-Security-Policy "frame-ancestors 'self' *.vaccineimpact.org" always;
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy 'origin' always;
+        add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()" always;
     }
 
     location /new-password {
          try_files /resources/new-password.html =404;
          expires -1;
          add_header Cache-Control "public";
+         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+         add_header Content-Security-Policy "frame-ancestors 'self' *.vaccineimpact.org" always;
+         add_header X-Frame-Options "SAMEORIGIN";
+         add_header X-Content-Type-Options "nosniff" always;
+         add_header Referrer-Policy 'origin' always;
+         add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()" always;
     }
 
     location /reset-password {
          try_files /resources/reset-password.html =404;
          expires -1;
          add_header Cache-Control "public";
+	 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+         add_header Content-Security-Policy "frame-ancestors 'self' *.vaccineimpact.org" always;
+         add_header X-Frame-Options "SAMEORIGIN";
+         add_header X-Content-Type-Options "nosniff" always;
+         add_header Referrer-Policy 'origin' always;
+         add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()" always;
     }
 
     # Resources for static page

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -3,6 +3,10 @@ server {
     listen       _PORT_ ssl;
     server_name  localhost  montagu.vaccineimpact.org;
 
+    # add_header inside a location section causes all top-level
+    # add_headers to be forgotten. Hence, move this one moved to 
+    # the top-level in VIMC-7074
+
     add_header Cache-Control "public";
 
     # Enable HTTP Strict Transport Security (HSTS)
@@ -44,9 +48,6 @@ server {
     error_page 404 /404.html;
 
     # Serve up a static page for confirming the server is running
-    # Note that the add_header Cache-Control causes all other add_headers to be forgotten,
-    # so need to paste the top-level ones again in this, and later location sections that
-    # declare the Cache-Control header. (See VIMC-7074)
 
     location = / {
         try_files /index.html =404;

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -3,12 +3,6 @@ server {
     listen       _PORT_ ssl;
     server_name  localhost  montagu.vaccineimpact.org;
 
-    # add_header inside a location section causes all top-level
-    # add_headers to be forgotten. Hence, move this one moved to 
-    # the top-level in VIMC-7074
-
-    add_header Cache-Control "public";
-
     # Enable HTTP Strict Transport Security (HSTS)
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -48,7 +48,6 @@ server {
     error_page 404 /404.html;
 
     # Serve up a static page for confirming the server is running
-
     location = / {
         try_files /index.html =404;
         expires -1;

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -3,6 +3,8 @@ server {
     listen       _PORT_ ssl;
     server_name  localhost  montagu.vaccineimpact.org;
 
+    add_header Cache-Control "public";
+
     # Enable HTTP Strict Transport Security (HSTS)
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
@@ -49,37 +51,16 @@ server {
     location = / {
         try_files /index.html =404;
         expires -1;
-        add_header Cache-Control "public";
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "frame-ancestors 'self' *.vaccineimpact.org" always;
-        add_header X-Frame-Options "SAMEORIGIN";
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy 'origin' always;
-        add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()" always;
     }
 
     location /new-password {
          try_files /resources/new-password.html =404;
          expires -1;
-         add_header Cache-Control "public";
-         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-         add_header Content-Security-Policy "frame-ancestors 'self' *.vaccineimpact.org" always;
-         add_header X-Frame-Options "SAMEORIGIN";
-         add_header X-Content-Type-Options "nosniff" always;
-         add_header Referrer-Policy 'origin' always;
-         add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()" always;
     }
 
     location /reset-password {
          try_files /resources/reset-password.html =404;
          expires -1;
-         add_header Cache-Control "public";
-	 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-         add_header Content-Security-Policy "frame-ancestors 'self' *.vaccineimpact.org" always;
-         add_header X-Frame-Options "SAMEORIGIN";
-         add_header X-Content-Type-Options "nosniff" always;
-         add_header Referrer-Policy 'origin' always;
-         add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()" always;
     }
 
     # Resources for static page


### PR DESCRIPTION
This makes sure HSTS turns on by copying `add_header` to places where it otherwise would not get inherited.

See https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-7074
and https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/
