### PR TITLE
mrc-5092 Proof of concept: login to packit from index page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     volumes:
      - token_key_volume:/etc/montagu/api/token_key
      - ${PWD}/montagu_emails:/tmp/montagu_emails
-  orderly_web_web:
+  orderly-web-web:
     image: ${ORG}/orderly-web:master
     networks:
      - proxy
@@ -26,11 +26,11 @@ services:
     volumes:
      - orderly_volume:/orderly
   packit:
-    image: mrcide/packit:main
+    image: mrcide/packit:mrc-5092
     networks:
       - proxy
-  packit_api:
-    image: mrcide/packit-api:main
+  packit-api:
+    image: mrcide/packit-api:mrc-5092
     networks:
       - proxy
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,14 @@ services:
     image: mrcide/packit-api:mrc-5092
     networks:
       - proxy
+  packit-db:
+    image: mrcide/packit-db:main
+    networks:
+      - proxy
+  outpack_server:
+    image: mrcide/outpack_server:main
+    networks:
+      - proxy
   db:
     image: ${ORG}/montagu-db:master
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       - proxy
   outpack_server:
     image: mrcide/outpack_server:main
+    volumes:
+      - ../packit/demos/orderly:/outpack # This requires packit repo to be cloned in same dir as montagu-proxy!
     networks:
       - proxy
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,14 @@ services:
       - api
     volumes:
      - orderly_volume:/orderly
+  packit:
+    image: mrcide/packit:main
+    networks:
+      - proxy
+  packit_api:
+    image: mrcide/packit-api:main
+    networks:
+      - proxy
   db:
     image: ${ORG}/montagu-db:master
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     image: mrcide/packit-api:mrc-5092
     networks:
       - proxy
+    depends_on:
+      - packit-db
   packit-db:
     image: mrcide/packit-db:main
     networks:
@@ -40,7 +42,7 @@ services:
   outpack_server:
     image: mrcide/outpack_server:main
     volumes:
-      - ../packit/demos/orderly:/outpack # This requires packit repo to be cloned in same dir as montagu-proxy!
+      - ./../packit/demos/orderly:/outpack # This requires packit repo to be cloned in same dir as montagu-proxy!
     networks:
       - proxy
   db:

--- a/index.html
+++ b/index.html
@@ -117,11 +117,18 @@
                 logic.getUserName().then((result) => {
                     data.username = result;
 
-                    const redirectLocation = utils.paramFromQueryString(location.search, "redirectTo");
-                    if (result && redirectLocation) {
-                        data.redirectMessage = `Redirecting you back to ${redirectLocation}.
+                    // If we have loggingOut param set, it means we're logging out from packit
+                    const loggingOut = utils.paramFromQueryString(location.search, "loggingOut");
+                    if (loggingOut) {
+                        this.logout();
+                    } else {
+
+                        const redirectLocation = utils.paramFromQueryString(location.search, "redirectTo");
+                        if (result && redirectLocation) {
+                            data.redirectMessage = `Redirecting you back to ${redirectLocation}.
                             If you are not automatically redirected in a few seconds please click <a href="${redirectLocation}">here</a>`;
-                        window.location.href = redirectLocation
+                            window.location.href = redirectLocation
+                        }
                     }
                 })
             },

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <script src="resources/js/montagu-login.js"></script>
     <script src="resources/js/montagu-auth.js"></script>
     <script src="resources/js/montagu-utils.js"></script>
+    <script src="resources/js/packit-auth.js"></script>
     <script src="resources/js/components/montagu-login-status.vue.js"></script>
     <script src="resources/js/components/montagu-login-form.vue.js"></script>
 </head>
@@ -94,7 +95,7 @@
 <script>
     const utils = MontaguUtils;
     const auth = new MontaguAuth(utils.getApiRoot());
-    const packitAuth = new PackitAuth(utils.getPackitRoot(), jwt_decode);
+    const packitAuth = new PackitAuth(utils.getPackitApiRoot(), jwt_decode);
     const logic = new MontaguLogin(
         auth,
         packitAuth,

--- a/index.html
+++ b/index.html
@@ -94,8 +94,10 @@
 <script>
     const utils = MontaguUtils;
     const auth = new MontaguAuth(utils.getApiRoot());
+    const packitAuth = new PackitAuth(utils.getPackitRoot(), jwt_decode);
     const logic = new MontaguLogin(
         auth,
+        packitAuth,
         jwt_decode,
         pako
     );

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -126,6 +126,14 @@ server {
         }
     }
 
+    set $packit http://packit:3000
+    location /packit/ {
+        resolver 127.0.0.11 valid=30s;
+        rewrite ^/packit/(.*) /$1 break;
+        proxy_pass $orderly_web;
+        proxy_redirect http://packit:3000/ /packit/;
+    }
+
     # Ideally these github bots would be on a separate proxy server
     # see https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-1280
     # Resolving dynamically for the same reason as above

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -126,13 +126,13 @@ server {
         }
     }
 
+    location /packit/api/ {
+            proxy_pass http://packit-api:8080/;
+            proxy_redirect default;
+        }
+
     location /packit/ {
         proxy_pass http://packit/;
-        proxy_redirect default;
-    }
-
-    location /packit-api/ {
-        proxy_pass http://packit-api:8080/;
         proxy_redirect default;
     }
 

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -127,9 +127,12 @@ server {
     }
 
     location /packit/api/ {
-            proxy_pass http://packit-api:8080/;
-            proxy_redirect default;
-        }
+        proxy_pass http://packit-api:8080/;
+        proxy_redirect default;
+    }
+
+    # Request for packit login goes to montagu index, and will redirect to packit on login
+    rewrite ^/packit/login$ /?redirectTo=packit permanent;
 
     location /packit/ {
         proxy_pass http://packit/;

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -132,6 +132,8 @@ server {
     }
 
     # Request for packit login goes to montagu index, and will redirect to packit on login
+    # The rewrite also passes through the loggingOut query string parameter which montagu uses to determine that logout
+    # has been requested from packit.
     # Still TODO: redirect to any requested url under packit
     rewrite ^/packit/login$ /?redirectTo=packit permanent;
 

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -114,24 +114,36 @@ server {
 
     # resolving /reports/ dynamically because the orderly web container may not be up when the proxy starts
     # for an explanation of this config see: https://tenzer.dk/nginx-with-dynamic-upstreams/
-    set $orderly_web http://orderly_web_web:8888;
+    set $orderly_web http://orderly-webweb:8888;
     location /reports/ {
         resolver 127.0.0.11 valid=30s;
         rewrite ^/reports/(.*) /$1 break;
         proxy_pass $orderly_web;
-        proxy_redirect http://orderly_web_web:8888/ /reports/;
+        proxy_redirect http://orderly-web-web:8888/ /reports/;
 
         location "~/reports/(?<name>[^/]+)/(?<version>\d{8}-\d{6}-[0-9a-f]{8})" {
             return 301 /reports/report/$name/$version;
         }
     }
 
-    set $packit http://packit:3000
+    #set $packit http://packit:3000;
     location /packit/ {
-        resolver 127.0.0.11 valid=30s;
-        rewrite ^/packit/(.*) /$1 break;
-        proxy_pass $orderly_web;
-        proxy_redirect http://packit:3000/ /packit/;
+        proxy_pass http://packit:3000/;
+        proxy_redirect default;
+        #resolver 127.0.0.11 valid=30s;
+        #rewrite ^/packit/(.*) /$1 break;
+        #proxy_pass $packit;
+        #proxy_redirect http://packit:3000/ /packit/;
+    }
+
+    #set $packit-api http://packit-api:8080;
+    location /packit-api/ {
+        proxy_pass http://packit-api:8080/;
+        proxy_redirect default;
+        #resolver 127.0.0.11 valid=30s;
+        #rewrite ^/packit-api/(.*) /$1 break;
+        #proxy_pass $packit;
+        #proxy_redirect http://packit-api:8080/ /packit-api/;
     }
 
     # Ideally these github bots would be on a separate proxy server

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -114,7 +114,7 @@ server {
 
     # resolving /reports/ dynamically because the orderly web container may not be up when the proxy starts
     # for an explanation of this config see: https://tenzer.dk/nginx-with-dynamic-upstreams/
-    set $orderly_web http://orderly-webweb:8888;
+    set $orderly_web http://orderly-web-web:8888;
     location /reports/ {
         resolver 127.0.0.11 valid=30s;
         rewrite ^/reports/(.*) /$1 break;

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -132,6 +132,7 @@ server {
     }
 
     # Request for packit login goes to montagu index, and will redirect to packit on login
+    # Still TODO: redirect to any requested url under packit
     rewrite ^/packit/login$ /?redirectTo=packit permanent;
 
     location /packit/ {

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -126,24 +126,14 @@ server {
         }
     }
 
-    #set $packit http://packit:3000;
     location /packit/ {
-        proxy_pass http://packit:3000/;
+        proxy_pass http://packit/;
         proxy_redirect default;
-        #resolver 127.0.0.11 valid=30s;
-        #rewrite ^/packit/(.*) /$1 break;
-        #proxy_pass $packit;
-        #proxy_redirect http://packit:3000/ /packit/;
     }
 
-    #set $packit-api http://packit-api:8080;
     location /packit-api/ {
         proxy_pass http://packit-api:8080/;
         proxy_redirect default;
-        #resolver 127.0.0.11 valid=30s;
-        #rewrite ^/packit-api/(.*) /$1 break;
-        #proxy_pass $packit;
-        #proxy_redirect http://packit-api:8080/ /packit-api/;
     }
 
     # Ideally these github bots would be on a separate proxy server

--- a/resources/js/montagu-login.js
+++ b/resources/js/montagu-login.js
@@ -56,7 +56,8 @@ class MontaguLogin {
     }
 
     logout() {
-
+        // Logout of packit by deleting token from storage
+        this.packitAuth.deleteUser();
         return this.montaguAuth.logout()
             .catch((jqXHR) => {
                 throw MontaguLogin.montaguApiError(jqXHR)

--- a/resources/js/montagu-login.js
+++ b/resources/js/montagu-login.js
@@ -1,8 +1,9 @@
 //Logic class for logging in and out of Montagu
 class MontaguLogin {
 
-    constructor(montaguAuth, jwt_decode, pako) {
+    constructor(montaguAuth, packitAuth, jwt_decode, pako) {
         this.montaguAuth = montaguAuth;
+        this.packitAuth = packitAuth;
         this.jwt_decode = jwt_decode;
         this.pako = pako;
     }
@@ -26,12 +27,21 @@ class MontaguLogin {
         return expiry > now
     }
 
-    login(email, password) {
-        return this.montaguAuth.login(email, password)
+    async login(email, password) {
+        const result = await this.montaguAuth.login(email, password)
             .then((data) => this.montaguLoginSuccess(data))
             .catch((jqXHR) => {
                 throw MontaguLogin.montaguApiError(jqXHR)
-            })
+            });
+        // Allow possibility for Montagu login to succeed but Packit login to fail - do
+        // so silently for this POC, but print to console
+        await this.packitAuth.login(email, password)
+            .then((data) => this.packitAuth.saveUser(data))
+            .catch((jqXHR) => {
+                console.log(`Packit login error: ${JSON.stringify(jqXHR)}`);
+            });
+
+        return result;    
     }
 
     montaguLoginSuccess(data) {

--- a/resources/js/montagu-utils.js
+++ b/resources/js/montagu-utils.js
@@ -5,7 +5,7 @@ class MontaguUtils {
     }
 
     static getPackitApiRoot() {
-        return "/packit-api/";
+        return "/packit/api/";
     }
 
     static paramFromQueryString(queryString, param) {

--- a/resources/js/montagu-utils.js
+++ b/resources/js/montagu-utils.js
@@ -4,8 +4,8 @@ class MontaguUtils {
         return "/api/v1/";
     }
 
-    static getPackitRoot() {
-        return "/packit/";
+    static getPackitApiRoot() {
+        return "/packit-api/";
     }
 
     static paramFromQueryString(queryString, param) {

--- a/resources/js/montagu-utils.js
+++ b/resources/js/montagu-utils.js
@@ -4,6 +4,10 @@ class MontaguUtils {
         return "/api/v1/";
     }
 
+    static getPackitRoot() {
+        return "/packit/";
+    }
+
     static paramFromQueryString(queryString, param) {
 
         if (!queryString) return null;

--- a/resources/js/packit-auth.js
+++ b/resources/js/packit-auth.js
@@ -4,7 +4,7 @@ class PackitAuth {
         this.jwt_decode = jwt_decode;
     }
 
-    // TODO: We should be using Authorization header here instead, like Montagu does?
+    // TODO: We should be using Authorization header here instead, like Montagu does
     login(email, password) {
         const data = JSON.stringify({email, password});
         const loginUrl = this.packitApiRoot + "auth/login/basic";

--- a/resources/js/packit-auth.js
+++ b/resources/js/packit-auth.js
@@ -1,0 +1,30 @@
+class PackitAuth {
+    constructor(packitRoot, jwt_decode) {
+        this.packitRoot = packitRoot;
+        this.jwt_decode = jwt_decode;
+    }
+
+    // TODO: We should be using Authorization header here instead, like Montagu does?
+    login(email, password) {
+        const loginUrl = this.packitRoot + "auth/login/basic";
+        return $.ajax({
+            type: "POST",
+            url: loginUrl,
+            data: {email, password},
+            headers: {
+                "Content-Type": "application/json"
+            }
+        });
+    }
+
+    saveUser(token) {
+        const decoded = this.jwt_decode(token);
+        const user = {
+            token,
+            exp: decoded.exp ?? 0,
+            displayName: decoded.displayName ?? "",
+            userName: decoded.userName ?? ""
+        };
+        localStorage.setItem("user", JSON.stringify(user));
+    }
+}

--- a/resources/js/packit-auth.js
+++ b/resources/js/packit-auth.js
@@ -1,23 +1,25 @@
 class PackitAuth {
-    constructor(packitRoot, jwt_decode) {
-        this.packitRoot = packitRoot;
+    constructor(packitApiRoot, jwt_decode) {
+        this.packitApiRoot = packitApiRoot;
         this.jwt_decode = jwt_decode;
     }
 
     // TODO: We should be using Authorization header here instead, like Montagu does?
     login(email, password) {
-        const loginUrl = this.packitRoot + "auth/login/basic";
+        const data = JSON.stringify({email, password});
+        const loginUrl = this.packitApiRoot + "auth/login/basic";
         return $.ajax({
             type: "POST",
             url: loginUrl,
-            data: {email, password},
+            data,
             headers: {
                 "Content-Type": "application/json"
             }
         });
     }
 
-    saveUser(token) {
+    saveUser(loginResponse) {
+        const token = loginResponse.token;
         const decoded = this.jwt_decode(token);
         const user = {
             token,
@@ -25,6 +27,6 @@ class PackitAuth {
             displayName: decoded.displayName ?? "",
             userName: decoded.userName ?? ""
         };
-        localStorage.setItem("user", JSON.stringify(user));
+        localStorage.setItem("user", JSON.stringify(user)); // TODO: don't save prototype!
     }
 }

--- a/resources/js/packit-auth.js
+++ b/resources/js/packit-auth.js
@@ -29,4 +29,9 @@ class PackitAuth {
         };
         localStorage.setItem("user", JSON.stringify(user)); // TODO: don't save prototype!
     }
+
+    deleteUser() {
+        localStorage.removeItem("user");
+    }
+
 }

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -10,7 +10,7 @@ function cleanup() {
     docker rm reverse-proxy || true
     docker stop montagu-metrics || true
     docker rm montagu-metrics || true
-    docker-compose --project-name montagu down || true
+    docker compose --project-name montagu down || true
 }
 
 export ORG=vimc

--- a/scripts/packitconfig.properties
+++ b/scripts/packitconfig.properties
@@ -2,6 +2,7 @@ outpack.server.url=http://outpack_server:8000
 db.url=jdbc:postgresql://packit-db:5432/packit?stringtype=unspecified
 db.user=packituser
 db.password=changeme
+app.route=/packit
 
 #Auth2
 auth.jwt.secret=changesecretkey

--- a/scripts/packitconfig.properties
+++ b/scripts/packitconfig.properties
@@ -1,5 +1,5 @@
-outpack.server.url=http://localhost:8000
-db.url=jdbc:postgresql://localhost:5432/packit?stringtype=unspecified
+outpack.server.url=http://outpack_server:8000
+db.url=jdbc:postgresql://packit-db:5432/packit?stringtype=unspecified
 db.user=packituser
 db.password=changeme
 

--- a/scripts/packitconfig.properties
+++ b/scripts/packitconfig.properties
@@ -1,0 +1,13 @@
+outpack.server.url=http://localhost:8000
+db.url=jdbc:postgresql://localhost:5432/packit?stringtype=unspecified
+db.user=packituser
+db.password=changeme
+
+#Auth2
+auth.jwt.secret=changesecretkey
+auth.oauth2.redirect.url=
+auth.method=basic
+auth.expiryDays=1
+auth.enabled=true
+auth.githubAPIOrg=none
+auth.githubAPITeam=none

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -25,11 +25,13 @@ docker cp $here/orderlywebconfig.properties montagu-orderly-web-web-1:/etc/order
 docker exec montagu-orderly-web-web-1 touch /etc/orderly/web/go_signal
 docker exec montagu-orderly-web-web-1 touch /etc/orderly/web/go_signal
 docker exec montagu-orderly-1 touch /orderly_go
-docker cp $here/packitconfig.properties montagu-packit-api-1:/etc/packit/config.properties
 
 # Packit db: Need to give the database a little time to initialise before we can run the migration
 docker exec montagu-packit-db-1 wait-for-db
 docker exec montagu-packit-db-1 psql -U packituser -d packit -a -f /packit-schema/schema.sql
+
+# Initialise packit-api after the db
+docker cp $here/packitconfig.properties montagu-packit-api-1:/etc/packit/config.properties
 
 # TODO: need this on CI?
 sleep 30

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -7,28 +7,31 @@ export ORG=vimc
 export TOKEN_KEY_PATH=$PWD/token_key
 
 function cleanup() {
-    docker-compose --project-name montagu down || true
+    docker compose --project-name montagu down || true
 }
 
 trap cleanup ERR
 
 # Run up all the APIs and Portals which are to be proxied
 docker volume rm montagu_orderly_volume -f
-docker-compose pull
-docker-compose --project-name montagu up -d
+docker compose pull
+docker compose --project-name montagu up -d
 
 # Start the APIs
-docker exec montagu_api_1 mkdir -p /etc/montagu/api/
-docker exec montagu_api_1 touch /etc/montagu/api/go_signal
-docker exec montagu_orderly_web_web_1 mkdir -p /etc/orderly/web
-docker cp $here/orderlywebconfig.properties montagu_orderly_web_web_1:/etc/orderly/web/config.properties
-docker exec montagu_orderly_web_web_1 touch /etc/orderly/web/go_signal
-docker exec montagu_orderly_web_web_1 touch /etc/orderly/web/go_signal
-docker exec montagu_orderly_1 touch /orderly_go
-docker cp $here/packitconfig.properties montagu_packit_api_1:/etc/packit/config.properties
+docker exec montagu-api-1 mkdir -p /etc/montagu/api/
+docker exec montagu-api-1 touch /etc/montagu/api/go_signal
+docker exec montagu-orderly-web-web-1 mkdir -p /etc/orderly/web
+docker cp $here/orderlywebconfig.properties montagu-orderly-web-web-1:/etc/orderly/web/config.properties
+docker exec montagu-orderly-web-web-1 touch /etc/orderly/web/go_signal
+docker exec montagu-orderly-web-web-1 touch /etc/orderly/web/go_signal
+docker exec montagu-orderly-1 touch /orderly_go
+docker cp $here/packitconfig.properties montagu-packit-api-1:/etc/packit/config.properties
+
+# TODO: need this on CI?
+sleep 30
 
 # Wait for the database
-docker exec montagu_db_1 montagu-wait.sh
+docker exec montagu-db-1 montagu-wait.sh
 
 # Migrate the database
 migrate_image=$ORG/montagu-migrate:master
@@ -55,7 +58,7 @@ docker run --rm \
   "."
 
 # Copy the demo db file to top level
-docker cp $PWD/demo/orderly.sqlite montagu_orderly_web_web_1:/orderly/orderly.sqlite
+docker cp $PWD/demo/orderly.sqlite montagu-orderly-web-web-1:/orderly/orderly.sqlite
 
 # Migrate the orderlyweb tables
 ow_migrate_image=$ORG/orderlyweb-migrate:master

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -25,6 +25,7 @@ docker cp $here/orderlywebconfig.properties montagu_orderly_web_web_1:/etc/order
 docker exec montagu_orderly_web_web_1 touch /etc/orderly/web/go_signal
 docker exec montagu_orderly_web_web_1 touch /etc/orderly/web/go_signal
 docker exec montagu_orderly_1 touch /orderly_go
+docker cp $here/packitconfig.properties montagu_packit_api_1:/etc/packit/config.properties
 
 # Wait for the database
 docker exec montagu_db_1 montagu-wait.sh

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -27,6 +27,10 @@ docker exec montagu-orderly-web-web-1 touch /etc/orderly/web/go_signal
 docker exec montagu-orderly-1 touch /orderly_go
 docker cp $here/packitconfig.properties montagu-packit-api-1:/etc/packit/config.properties
 
+# Packit db: Need to give the database a little time to initialise before we can run the migration
+docker exec montagu-packit-db-1 wait-for-db
+docker exec montagu-packit-db-1 psql -U packituser -d packit -a -f /packit-schema/schema.sql
+
 # TODO: need this on CI?
 sleep 30
 


### PR DESCRIPTION
The changes in this PR, and the [related Packit PR](https://github.com/mrc-ide/packit/pull/53) are a proof of concept to show how we can support Montagu auth in Packit. These branches should not be merged but will form the basis of further tickets to do a full implementation. 

Unlike our approach in OrderlyWeb, where Montagu auth was a special case, and where OrderlyWeb interacted directly with Montagu API to deal with Auth, here we support Basic Auth in Packit, which knows nothing about Montagu. Instead, it's Montagu which will work with Packit's auth requirements. We'll migrate Montagu users into the Packit DB as Packit users, and make the add user admin feature in Montagu create a corresponding new user in Packit. So here the bulk of the work is implementing Basic auth in Packit and integrating Packit into the Montagu proxy, ensuring that login requests to Packit are routed via the Montagu login page, which authenticates with both Montagu and Packit. 

I'm sure there are some wrinkles to iron out here - you may have a weird experience with multiple tabs or back button. As @richfitz pointed out, we should also make sure Montagu and Packit tokens are given the same expiry duration....

The changes in these PRs cover the following aspects:
### 1. SUPPORTING BASIC AUTH IN PACKIT

I've reinstated Lekan's old Basic auth, somewhat changed for the refactored security classes. This uses a JSON POST of credentials, but we should put credentials in the Authorization header when we implement this for real. There isn't actually a user database as yet, just a single hardcoded test user. You can see the implementation in the backend changes in Packit, which includes some refactoring of the user principal classes to support both Basic and OAuth2 users. 

### 2. ADDING PACKIT TO MONTAGU-PROXY DEMO

Packit containers added to Docker compose and added some config wrangling in related scripts. 

### 3. ROUTING PACKIT REQUESTS IN MONTAGU PROXY

`nginx.montagu.conf` updated to route requests under `/packit` to the Packit front end container, and under `/packit/api` to the Packit back end container:
```
location /packit/api/ {
    proxy_pass http://packit-api:8080/;
    proxy_redirect default;
}

location /packit/ {
    proxy_pass http://packit/;
    proxy_redirect default;
}
```
This assumes that packit will be running in the same docker network as the proxy (as we did for OW). 


### 4. LOGGING INTO PACKIT WHEN LOG IN TO MONTAGU

The `login` method in `montagu-login.js`, called from the montagu index page, now also logs into Packit, via a new `packit-auth.js`module, which gets the Packit token from the api's `auth/login/basic` endpoint and saves it to local storage, as expected by Packit. 

### 5. REDIRECTING FROM PACKIT LOGIN PAGE TO MONTAGU LOGIN PAGE

`nginx.montagu.conf` updated to redirect requests to the packit login page to the index page, where the user can login. Sets the `redirectTo` qs param, so that the user is automatically redirected to Packit after login with Montagu.
```
rewrite ^/packit/login$ /?redirectTo=packit permanent;
```
What isn't implemented yet is redirecting to any initially requested page within Packit e.g. a Packit group page. 


### 6. REDIRECTING FROM PACKIT PROTECTED ROUTES TO MONTAGU LOGIN PAGE

Usually, the user wouldn't browse direct to `/packit/login` to login, but instead would be directed there by Packit itself when they attempt to access a protected route (e.g the Packit home page). We want users to be redirected to the Montagu page in these cases too, but this required a change in Packit. so that rather than using front-end only react router navigating, it uses ordinary window.location navigation, which round trips to the server and gives the proxy the opportunity to do the redirect. This is implemented in `ProtectedRoute.tsx` and in `AccountHeaderDropdown.tsx` (to cover the case where the user explicitly logs out and is directed to the login page). 

### 7. LOGGING OUT FROM MONTAGU PAGE
When the user logs out from the Montagu index page, it also 'logs out' of Packit by calling `deleteUser` in `packit-auth.js` to delete the token from local storage.  

### 8. LOGGING OUT FROM PACKIT
When the user logs out explicity from Packit, as well as being directed to the Montagu index page, they should also be logged out of Montagu, so we need some way of telling Montagu that it needs to log out too. So, when Packit's `AccountHeaderDropdown.tsx` redirects with the new window navigation on logout, it also includes a `loggingOut=1` query string. This is not used within Packit (which already knows to delete the token), but is picked up by the Montagu index page (the nginx rewrite configuration passes the parameter through) - if the `loggingOut` param is present, the index page will log out of Montagu on page load. 

### TESTING
To test locally, run `./scripts/dev.sh`, browse to https://localhost and push through the dire warnings to get to the Montagu index page. I haven't added a button to take you directly to Packit, but once you've logged in (as test.user@example.com) you should be able to browse to https://localhost/packit to see the Packit front page, logged in as the test user. (You'll also be able to see some packets if you run up the proxy in a folder at the same level as a `packit` folder with an initialised outpack demo). 

You should be able to do all the actions described above e.g. get redirected to Montagu when log out from Packit, get redirected to Montagu if browse to https://localhost/packit when not logged in etc. 