### PR TITLE
Update for new constellation deployment.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ x-logging: &log-journald
 
 services:
   api:
-    image: ${ORG}/montagu-api:abf39a2
+    image: ${ORG}/montagu-api:master
     ports:
      - "8080:8080"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+name: 'montagu'
 
 x-logging: &log-journald
   driver: journald
@@ -17,7 +17,10 @@ services:
     volumes:
      - token_key_volume:/etc/montagu/api/token_key
      - ${PWD}/montagu_emails:/tmp/montagu_emails
-  orderly_web_web:
+
+  # The stutter in the name is needed to match the constellation deployment,
+  # which uses orderly-web as the container prefix, and web as the suffix.
+  orderly-web-web:
     image: ${ORG}/orderly-web:master
     networks:
      - proxy
@@ -54,19 +57,10 @@ services:
      - proxy
     depends_on:
      - api
-  static:
-    image: ${ORG}/montagu-static:master
-    networks:
-     - proxy
-    volumes:
-    - static_volume:/www
-    - static_logs:/var/log/caddy
 volumes:
   orderly_volume:
   template_volume:
   guidance_volume:
-  static_logs:
-  static_volume:
   token_key_volume:
 networks:
   proxy:

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -79,18 +79,6 @@ server {
     location /2021/visualisation/ {
     }
 
-    # Static resources behind jwt auth
-    location /model-documentation/ {
-      proxy_pass http://static:80/model-documentation/;
-      proxy_redirect default;
-    }
-
-    # Static resources behind jwt auth
-    location /estimate-comparison/ {
-      proxy_pass http://static:80/estimate-comparison/;
-      proxy_redirect default;
-    }
-
     # Pass through to different containers based on url prefix.
     location /api/ {
         proxy_pass http://api:8080/;
@@ -114,12 +102,12 @@ server {
 
     # resolving /reports/ dynamically because the orderly web container may not be up when the proxy starts
     # for an explanation of this config see: https://tenzer.dk/nginx-with-dynamic-upstreams/
-    set $orderly_web http://orderly_web_web:8888;
+    set $orderly_web http://orderly-web-web:8888;
     location /reports/ {
         resolver 127.0.0.11 valid=30s;
         rewrite ^/reports/(.*) /$1 break;
         proxy_pass $orderly_web;
-        proxy_redirect http://orderly_web_web:8888/ /reports/;
+        proxy_redirect http://orderly-web-web:8888/ /reports/;
 
         location "~/reports/(?<name>[^/]+)/(?<version>\d{8}-\d{6}-[0-9a-f]{8})" {
             return 301 /reports/report/$name/$version;

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -10,7 +10,7 @@ function cleanup() {
     docker rm reverse-proxy || true
     docker stop montagu-metrics || true
     docker rm montagu-metrics || true
-    docker-compose --project-name montagu down || true
+    docker compose down || true
 }
 
 export ORG=vimc

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -28,7 +28,7 @@ docker run --rm \
     $ORG/montagu-cert-tool:master \
     gen-self-signed /workspace > /dev/null 2> /dev/null
 
-$here/run-dependencies.sh
+$here/run-dependencies.sh "$@"
 
 # Build and run the proxy and metrics containers
 docker build -t reverse-proxy .

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -7,28 +7,28 @@ export ORG=vimc
 export TOKEN_KEY_PATH=$PWD/token_key
 
 function cleanup() {
-    docker-compose --project-name montagu logs
-    docker-compose --project-name montagu down || true
+    docker compose logs
+    docker compose down || true
 }
 
 trap cleanup ERR
 
 # Run up all the APIs and Portals which are to be proxied
 docker volume rm montagu_orderly_volume -f
-docker-compose pull
-docker-compose --project-name montagu up -d
+docker compose pull
+docker compose up -d
 
 # Start the APIs
-docker exec montagu_api_1 mkdir -p /etc/montagu/api/
-docker exec montagu_api_1 touch /etc/montagu/api/go_signal
-docker exec montagu_orderly_web_web_1 mkdir -p /etc/orderly/web
-docker cp $here/orderlywebconfig.properties montagu_orderly_web_web_1:/etc/orderly/web/config.properties
-docker exec montagu_orderly_web_web_1 touch /etc/orderly/web/go_signal
-docker exec montagu_orderly_web_web_1 touch /etc/orderly/web/go_signal
-docker exec montagu_orderly_1 touch /orderly_go
+docker compose exec api mkdir -p /etc/montagu/api/
+docker compose exec api touch /etc/montagu/api/go_signal
+docker compose exec orderly-web-web mkdir -p /etc/orderly/web
+docker compose cp $here/orderlywebconfig.properties orderly-web-web:/etc/orderly/web/config.properties
+docker compose exec orderly-web-web touch /etc/orderly/web/go_signal
+docker compose exec orderly-web-web touch /etc/orderly/web/go_signal
+docker compose exec orderly touch /orderly_go
 
 # Wait for the database
-docker exec montagu_db_1 montagu-wait.sh 120
+docker compose exec db montagu-wait.sh 120
 
 # Migrate the database
 migrate_image=$ORG/montagu-migrate:master
@@ -55,7 +55,7 @@ docker run --rm \
   "."
 
 # Copy the demo db file to top level
-docker cp $PWD/demo/orderly.sqlite montagu_orderly_web_web_1:/orderly/orderly.sqlite
+docker compose cp $PWD/demo/orderly.sqlite orderly-web-web:/orderly/orderly.sqlite
 
 # Migrate the orderlyweb tables
 ow_migrate_image=$ORG/orderlyweb-migrate:master


### PR DESCRIPTION
This is picking up changes from PR #84.

The constellation based deployment uses dashes as the container name separator, which needs some updating in the nginx file. To make this repository test environment work, we switch to docker compose v2 which uses the same names.

It seems the static file paths weren't needed anymore, so these bits are removed.