### PR TITLE
Mrc-6373 User Authorization no longer in JWT

### DIFF
--- a/resources/js/packit-auth.js
+++ b/resources/js/packit-auth.js
@@ -32,7 +32,6 @@ class PackitAuth {
             exp: decoded.exp || 0,
             displayName: decoded.displayName || "",
             userName: decoded.userName || "",
-            authorities: decoded.au || []
         };
         localStorage.setItem(USER_KEY, JSON.stringify(user));
     }

--- a/tests/packit-auth.test.js
+++ b/tests/packit-auth.test.js
@@ -27,8 +27,7 @@ test("can save user", () => {
     const mockDecode = jest.fn(() => ({
         exp: 100,
         displayName: "Test User",
-        userName: "test.user",
-        au: ["packet.read"]
+        userName: "test.user"
     }));
     const token = "test_token";
     const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
@@ -39,7 +38,6 @@ test("can save user", () => {
         exp: 100,
         displayName: "Test User",
         userName: "test.user",
-        authorities: ["packet.read"]
     });
     expect(setItemSpy).toHaveBeenCalledWith("user", expectedSavedUser);
 });


### PR DESCRIPTION
This is a companion PR to the packet [PR](https://github.com/mrc-ide/packit/pull/206). The main change is that authorities are no longer stored in the JWT and thus no longer in local storage. Packit fetches these authorities and stores them in memory.