### PR TITLE
Rename packit containers to drop the orderly-web prefix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,22 +27,22 @@ services:
       - api
     volumes:
       - orderly_volume:/orderly
-  orderly-web-packit:
+  packit-packit:
     image: mrcide/montagu-packit:main
     networks:
       - proxy
-  orderly-web-packit-api:
+  packit-packit-api:
     image: mrcide/packit-api:main
     networks:
       - proxy
     depends_on:
-      orderly-web-packit-db:
+      packit-packit-db:
         condition: service_healthy
       outpack_server:
         condition: service_started
     environment:
       - PACKIT_OUTPACK_SERVER_URL=http://outpack_server:8000
-      - PACKIT_DB_URL=jdbc:postgresql://orderly-web-packit-db:5432/packit?stringtype=unspecified
+      - PACKIT_DB_URL=jdbc:postgresql://packit-packit-db:5432/packit?stringtype=unspecified
       - PACKIT_DB_USER=packituser
       - PACKIT_DB_PASSWORD=changeme
       - PACKIT_JWT_SECRET=changesecretkey
@@ -52,7 +52,7 @@ services:
       - PACKIT_AUTH_ENABLED=true
       - PACKIT_AUTH_GITHUB_ORG=none
       - PACKIT_AUTH_GITHUB_TEAM=none
-  orderly-web-packit-db:
+  packit-packit-db:
     image: mrcide/packit-db:main
     networks:
       - proxy

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -137,7 +137,7 @@ server {
         proxy_set_header Authorization "";
 
         # send to packit
-        proxy_pass http://orderly-web-packit-api:8080/auth/login/preauth;
+        proxy_pass http://packit-packit-api:8080/auth/login/preauth;
     }
 
     # Lockdown packit preauth login to external access - should be available for
@@ -147,7 +147,7 @@ server {
     }
 
     location /packit/api/ {
-        proxy_pass http://orderly-web-packit-api:8080/;
+        proxy_pass http://packit-packit-api:8080/;
         proxy_redirect default;
     }
 
@@ -158,7 +158,7 @@ server {
     rewrite ^/packit/login$ /?redirectTo=packit/redirect permanent;
 
     location /packit/ {
-        proxy_pass http://orderly-web-packit/;
+        proxy_pass http://packit-packit/;
         proxy_redirect default;
     }
 

--- a/scripts/packit-create-test-user.sh
+++ b/scripts/packit-create-test-user.sh
@@ -8,4 +8,4 @@ EMAIL='test.user@example.com'
 DISPLAY_NAME='Test User'
 ROLE='ADMIN'
 
-docker exec montagu-orderly-web-packit-db-1 create-preauth-user --username "$USERNAME" --email "$EMAIL" --displayname "$DISPLAY_NAME" --role "$ROLE"
+docker exec montagu-packit-packit-db-1 create-preauth-user --username "$USERNAME" --email "$EMAIL" --displayname "$DISPLAY_NAME" --role "$ROLE"


### PR DESCRIPTION
There will be a small tweak required to the montagu-config repo as welll