### PR TITLE
Defer resolution of packit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY resources /usr/share/nginx/html/resources
 ADD https://ssl-config.mozilla.org/ffdhe2048.txt /etc/nginx/dhparam.pem
 
 # Copy third party javascript from npm modules
-ENV THIRDPARTY_JS_PATH /usr/share/nginx/html/resources/js/third_party/
+ENV THIRDPARTY_JS_PATH=/usr/share/nginx/html/resources/js/third_party/
 COPY --from=0 /workspace/node_modules/pako/dist/pako.min.js $THIRDPARTY_JS_PATH
 COPY --from=0 /workspace/node_modules/vue/dist/vue.min.js $THIRDPARTY_JS_PATH
 COPY --from=0 /workspace/node_modules/jwt-decode/build/jwt-decode.min.js $THIRDPARTY_JS_PATH

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -100,6 +100,19 @@ server {
         proxy_pass http://contrib/;
     }
 
+    # See https://tenzer.dk/nginx-with-dynamic-upstreams/ Since 1.23.7
+    # we can use the 'resolve' parameter within the 'server' directive
+    # in the 'upstream' block, so here it is:
+    upstream packitapp {
+        resolver 127.0.0.11 valid=30s;
+        server http://packit resolve;
+    }
+
+    upstream packitapi {
+        resolver 127.0.0.11 valid=30s;
+        server http://packit-api:8080 resolve;
+    }
+
     # resolving /reports/ dynamically because the orderly web container may not be up when the proxy starts
     # for an explanation of this config see: https://tenzer.dk/nginx-with-dynamic-upstreams/
     set $orderly_web http://orderly-web-web:8888;
@@ -121,13 +134,7 @@ server {
         proxy_set_header Content-Length "";
     }
 
-    # Two variables h4ere, one for packit-api, and the other for packit (the app)
-    set $packitapi http://packit-api:8080;
-    set $packitapp http://packit;
-
     location /packit/api/auth/login/montagu {
-        resolver 127.0.0.11 valid=30s;
-
         # Verify user details with Montagu - this should fail if Authorzation header (Bearer token) is invalid
         auth_request /montagu-verify;
 
@@ -143,7 +150,7 @@ server {
         proxy_set_header Authorization "";
 
         # send to packit
-        proxy_pass $packitapi/auth/login/preauth;
+        proxy_pass http://packitapi/auth/login/preauth;
     }
 
     # Lockdown packit preauth login to external access - should be available for
@@ -153,8 +160,7 @@ server {
     }
 
     location /packit/api/ {
-        resolver 127.0.0.11 valid=30s;
-        proxy_pass $packitapi;
+        proxy_pass http://packitapi/;
         proxy_redirect default;
     }
 
@@ -165,8 +171,7 @@ server {
     rewrite ^/packit/login$ /?redirectTo=packit/redirect permanent;
 
     location /packit/ {
-        resolver 127.0.0.1 valid=30s;
-        proxy_pass $packitapp;
+        proxy_pass http://packitapp/;
         proxy_redirect default;
     }
 

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -1,3 +1,16 @@
+# See https://tenzer.dk/nginx-with-dynamic-upstreams/ Since 1.23.7
+# we can use the 'resolve' parameter within the 'server' directive
+# in the 'upstream' block, so here it is:
+upstream packitapp {
+    resolver 127.0.0.11 valid=30s;
+    server http://packit resolve;
+}
+
+upstream packitapi {
+    resolver 127.0.0.11 valid=30s;
+    server http://packit-api:8080 resolve;
+}
+
 # Main server configuration. See below for redirects.
 server {
     listen       _PORT_ ssl;
@@ -98,19 +111,6 @@ server {
     }
     location /contribution/ {
         proxy_pass http://contrib/;
-    }
-
-    # See https://tenzer.dk/nginx-with-dynamic-upstreams/ Since 1.23.7
-    # we can use the 'resolve' parameter within the 'server' directive
-    # in the 'upstream' block, so here it is:
-    upstream packitapp {
-        resolver 127.0.0.11 valid=30s;
-        server http://packit resolve;
-    }
-
-    upstream packitapi {
-        resolver 127.0.0.11 valid=30s;
-        server http://packit-api:8080 resolve;
     }
 
     # resolving /reports/ dynamically because the orderly web container may not be up when the proxy starts

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -4,11 +4,13 @@
 upstream packitapp {
     resolver 127.0.0.11 valid=30s;
     server packit resolve;
+    zone montagu 1m;
 }
 
 upstream packitapi {
     resolver 127.0.0.11 valid=30s;
     server packit-api:8080 resolve;
+    zone montagu 1m;
 }
 
 # Main server configuration. See below for redirects.

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -121,7 +121,13 @@ server {
         proxy_set_header Content-Length "";
     }
 
+    # Two variables h4ere, one for packit-api, and the other for packit (the app)
+    set $packitapi http://packit-api:8080;
+    set $packitapp http://packit;
+
     location /packit/api/auth/login/montagu {
+        resolver 127.0.0.11 valid=30s;
+
         # Verify user details with Montagu - this should fail if Authorzation header (Bearer token) is invalid
         auth_request /montagu-verify;
 
@@ -137,7 +143,7 @@ server {
         proxy_set_header Authorization "";
 
         # send to packit
-        proxy_pass http://packit-api:8080/auth/login/preauth;
+        proxy_pass $packitapi/auth/login/preauth;
     }
 
     # Lockdown packit preauth login to external access - should be available for
@@ -147,7 +153,8 @@ server {
     }
 
     location /packit/api/ {
-        proxy_pass http://packit-api:8080/;
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass $packitapi;
         proxy_redirect default;
     }
 
@@ -158,7 +165,8 @@ server {
     rewrite ^/packit/login$ /?redirectTo=packit/redirect permanent;
 
     location /packit/ {
-        proxy_pass http://packit/;
+        resolver 127.0.0.1 valid=30s;
+        proxy_pass $packitapp;
         proxy_redirect default;
     }
 

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -3,12 +3,12 @@
 # in the 'upstream' block, so here it is:
 upstream packitapp {
     resolver 127.0.0.11 valid=30s;
-    server http://packit resolve;
+    server packit resolve;
 }
 
 upstream packitapi {
     resolver 127.0.0.11 valid=30s;
-    server http://packit-api:8080 resolve;
+    server packit-api:8080 resolve;
 }
 
 # Main server configuration. See below for redirects.

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -4,7 +4,7 @@ set -ex
 HERE=$(dirname $0)
 . $HERE/common
 
-docker build \
+docker build --pull \
     -t $BRANCH_TAG \
     -t $SHA_TAG \
     .


### PR DESCRIPTION
This PR uses the new way of deferring resolution of addresses until runtime, as mentioned in the blog post that used our previous hack: https://tenzer.dk/nginx-with-dynamic-upstreams/

For OW we do:

```
    set $orderly_web http://orderly-web-web:8888;
    location /reports/ {
        resolver 127.0.0.11 valid=30s;
        rewrite ^/reports/(.*) /$1 break;
        proxy_pass $orderly_web;
        proxy_redirect http://orderly-web-web:8888/ /reports/;
    }
```

which exploits a hack in nginx that allows runtime host resolution. This was hard to adapt for packit because some of the configuration options in the preauth block were not compatible with use with the variable.  But all is good because since November we can use the recommended way of doing this anyway, which is mentioned in the blog post though quite cryptically.

Some other small housekeeping changes here - pull the base image on build and use the new syntax for envvars in the image. Deployed atm on uat, and things seem ok - I can log in and get to packit fine