### PR TITLE
Upgrade base docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-buster
+FROM node:24
 
 WORKDIR /workspace
 COPY . /workspace

--- a/dev/minimal.dockerfile
+++ b/dev/minimal.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-buster
+FROM node:24
 
 WORKDIR /workspace
 COPY . /workspace

--- a/integration-tests.dockerfile
+++ b/integration-tests.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-buster
+FROM node:24
 
 RUN apt-get update && apt-get install -yq \
                 fonts-liberation \


### PR DESCRIPTION
The build is failing (see master) because the proxy is based on ancient node images.  I've just pulled these up to the current version for now, but we might simplify this at some point in the future