### PR TITLE
mrc-6700 Proxy packit api and outpack server prometheus metrics endpoints

### DIFF
--- a/buildkite/demos/orderly/.outpack/config.json
+++ b/buildkite/demos/orderly/.outpack/config.json
@@ -1,0 +1,1 @@
+{"core":{"path_archive":null,"use_file_store":true,"require_complete_tree":true,"hash_algorithm":"sha256"},"location":[{"name":"local","type":"local","args":{}}]}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,10 +28,10 @@ services:
     depends_on:
       packit-db:
         condition: service_healthy
-      outpack_server:
+      outpack-server:
         condition: service_started
     environment:
-      - PACKIT_OUTPACK_SERVER_URL=http://outpack_server:8000
+      - PACKIT_OUTPACK_SERVER_URL=http://outpack-server:8000
       - PACKIT_DB_URL=jdbc:postgresql://packit-db:5432/packit?stringtype=unspecified
       - PACKIT_DB_USER=packituser
       - PACKIT_DB_PASSWORD=changeme
@@ -48,7 +48,7 @@ services:
       - proxy
     healthcheck:
       test: ["CMD", "wait-for-db"]
-  outpack_server:
+  outpack-server:
     image: ghcr.io/mrc-ide/outpack_server:main
     volumes:
       - ${OUTPACK_ROOT}:/outpack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
   outpack_server:
     image: ghcr.io/mrc-ide/outpack_server:main
     volumes:
-      - ./../packit/demos/orderly:/outpack # This requires packit repo to be cloned in same dir as montagu-proxy!
+      - ${OUTPACK_ROOT}:/outpack
     networks:
       - proxy
   db:

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -181,7 +181,6 @@ server {
     }
 
     # metrics endpoints for prometheus
-    # TODO: support custom packit api port
     location /packit-api/metrics {
         proxy_pass http://packitapi-metrics/prometheus;
     }

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -180,15 +180,6 @@ server {
         proxy_redirect default;
     }
 
-    # metrics endpoints for prometheus
-    location /packit-api/metrics {
-        proxy_pass http://packitapi-metrics/prometheus;
-    }
-
-    location /outpack_server/metrics {
-        proxy_pass http://outpackserver/metrics;
-    }
-
     # see https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-1280
     # Resolving dynamically for the same reason as above
     location /pull-request/ {
@@ -228,5 +219,18 @@ server {
 
     location / {
         return 301 https://_HOST_$request_uri;
+    }
+}
+
+server {
+    listen 9000;
+
+    # metrics endpoints for prometheus
+    location /metrics/packit-api {
+        proxy_pass http://packitapi-metrics/prometheus;
+    }
+
+    location /metrics/outpack_server {
+        proxy_pass http://outpackserver/metrics;
     }
 }

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -13,6 +13,18 @@ upstream packitapi {
     zone montagu 1m;
 }
 
+upstream packitapi-metrics {
+    resolver 127.0.0.11 valid=30s;
+    server packit-api:8081 resolve;
+    zone montagu 1m;
+}
+
+upstream outpackserver {
+    resolver 127.0.0.11 valid=30s;
+    server outpack_server:8000 resolve;
+    zone montagu 1m;
+}
+
 # Main server configuration. See below for redirects.
 server {
     listen       _PORT_ ssl;
@@ -168,7 +180,16 @@ server {
         proxy_redirect default;
     }
 
-    # Ideally these github bots would be on a separate proxy server
+    # metrics endpoints for prometheus
+    # TODO: support custom packit api port
+    location /packit-api/metrics {
+        proxy_pass http://packitapi-metrics/prometheus;
+    }
+
+    location /outpack_server/metrics {
+        proxy_pass http://outpackserver/metrics;
+    }
+
     # see https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-1280
     # Resolving dynamically for the same reason as above
     location /pull-request/ {

--- a/nginx.montagu.conf
+++ b/nginx.montagu.conf
@@ -21,7 +21,7 @@ upstream packitapi-metrics {
 
 upstream outpackserver {
     resolver 127.0.0.11 valid=30s;
-    server outpack_server:8000 resolve;
+    server outpack-server:8000 resolve;
     zone montagu 1m;
 }
 

--- a/scripts/clear-docker.sh
+++ b/scripts/clear-docker.sh
@@ -1,5 +1,5 @@
 docker ps -aq | xargs -r docker stop
-docker volume rm montagu_packit_db
+docker volume rm montagu_packit_db || true
 docker container prune --force
 docker volume prune --force
 docker network prune --force

--- a/scripts/common
+++ b/scripts/common
@@ -13,6 +13,17 @@ else
     GIT_BRANCH=$(git symbolic-ref --short HEAD)
 fi
 
+# if we're not running on buildkite, assume we have a local clone of
+# the packit repo we can point outpack server so we can see some
+# packets when running locally - otherwise use the minimal orderly
+# config in the buildkite folder so the outpack server container
+# starts up successfully for integration testing
+if [ "$BUILDKITE" = "true" ]; then
+    OUTPACK_ROOT=./buildkite/demos/orderly
+else
+    OUTPACK_ROOT=./../packit/demos/orderly
+fi
+
 # Deal with dependabot tags which look like
 #
 #   dependabot/npm_and_yarn/app/lodash-4.17.19

--- a/scripts/common
+++ b/scripts/common
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-ORG=vimc
+export ORG=vimc
 
 if [ "$BUILDKITE" = "true" ]; then
     GIT_SHA=${BUILDKITE_COMMIT:0:7}
@@ -19,9 +19,9 @@ fi
 # config in the buildkite folder so the outpack server container
 # starts up successfully for integration testing
 if [ "$BUILDKITE" = "true" ]; then
-    OUTPACK_ROOT=./buildkite/demos/orderly
+    export OUTPACK_ROOT=./buildkite/demos/orderly
 else
-    OUTPACK_ROOT=./../packit/demos/orderly
+    export OUTPACK_ROOT=./../packit/demos/orderly
 fi
 
 # Deal with dependabot tags which look like

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 here=$(dirname $0)
+. $here/common
 
 function cleanup() {
     # Pull down old containers
@@ -12,8 +13,6 @@ function cleanup() {
     docker rm montagu-metrics || true
     docker compose down || true
 }
-
-export ORG=vimc
 
 cleanup
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -26,7 +26,7 @@ $here/run-dependencies.sh "$@"
 # Build and run the proxy and metrics containers
 docker build -t reverse-proxy .
 docker run -d \
-	-p "443:443" -p "80:80" \
+	-p "443:443" -p "80:80" -p "9000:9000" \
 	--name reverse-proxy \
 	--network montagu_proxy\
 	reverse-proxy 443 localhost

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -32,6 +32,10 @@ docker run -d \
   nginx/nginx-prometheus-exporter:0.2.0 \
   -nginx.scrape-uri "http://reverse-proxy/basic_status"
 
+#TODO: remove debug
+docker ps
+docker exec reverse-proxy curl http://outpack_server:8000/metrics
+
 docker run \
   --rm \
 	--network host \

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -14,17 +14,17 @@ trap cleanup EXIT
 
 # We need to have an orderly demo folder available for outpack_server container to become available - see README for
 # suggestion for local setup. If we're on Buildkit, write out a minimal config and the server should spin up
-if [[ "$BUILDKITE" = "true" ]]; then
-    OUTPACK_ROOT=$HERE/../../packit/demos/orderly/.outpack
-    OUTPACK_CONFIG_FILE=$OUTPACK_ROOT/config.json
-    if [ ! -f $OUTPACK_CONFIG_FILE ]; then
-        echo "Testing local mkdir"
-        mkdir -p $HERE/testdir || true
-        echo "Creating outpack config file"
-        mkdir -p $OUTPACK_ROOT || true
-        echo '{"core":{"path_archive":null,"use_file_store":true,"require_complete_tree":true,"hash_algorithm":"sha256"},"location":[{"name":"local","type":"local","args":{}}]}' > $OUTPACK_CONFIG_FILE || true
-    fi
-fi
+#if [[ "$BUILDKITE" = "true" ]]; then
+#    OUTPACK_ROOT=$HERE/../../packit/demos/orderly/.outpack
+#    OUTPACK_CONFIG_FILE=$OUTPACK_ROOT/config.json
+#    if [ ! -f $OUTPACK_CONFIG_FILE ]; then
+#        echo "Testing local mkdir"
+#        mkdir -p $HERE/testdir || true
+#        echo "Creating outpack config file"
+#        mkdir -p $OUTPACK_ROOT || true
+#        echo '{"core":{"path_archive":null,"use_file_store":true,"require_complete_tree":true,"hash_algorithm":"sha256"},"location":[{"name":"local","type":"local","args":{}}]}' > $OUTPACK_CONFIG_FILE || true
+#    fi
+#fi
 
 mkdir montagu_emails
 $HERE/run-dependencies.sh

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -8,6 +8,7 @@ function cleanup() {
     # Pull down old containers
     rm -rf workspace || true
     rm -rf montagu_emails || true
+    $HERE/clear-docker.sh
 }
 
 trap cleanup EXIT

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -8,10 +8,21 @@ function cleanup() {
     # Pull down old containers
     rm -rf workspace || true
     rm -rf montagu_emails || true
-    $HERE/clear-docker.sh
 }
 
 trap cleanup EXIT
+
+# We need to have an orderly demo folder available for outpack_server container to become available - see README for
+# suggestion for local setup. If we're on Buildkit, write out a minimal config and the server should spin up
+if [[ "$BUILDKITE" = "true" ]]; then
+    OUTPACK_ROOT=$HERE/../../packit/demos/orderly/.outpack
+    OUTPACK_CONFIG_FILE=$OUTPACK_ROOT/config.json
+    if [ ! -f $OUTPACK_CONFIG_FILE ]; then
+        echo "Creating outpack config file"
+        mkdir -p $OUTPACK_ROOT || true
+        echo '{"core":{"path_archive":null,"use_file_store":true,"require_complete_tree":true,"hash_algorithm":"sha256"},"location":[{"name":"local","type":"local","args":{}}]}' > $OUTPACK_CONFIG_FILE || true
+    fi
+fi
 
 mkdir montagu_emails
 $HERE/run-dependencies.sh

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -34,6 +34,7 @@ docker run -d \
 
 #TODO: remove debug
 docker ps
+docker logs montagu-outpack_server-1
 docker exec reverse-proxy curl http://outpack_server:8000/metrics
 
 docker run \

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -19,7 +19,7 @@ $HERE/run-dependencies.sh
 export ORG=vimc
 
 docker run -d \
-	-p "443:443" -p "80:80" \
+	-p "443:443" -p "80:80" -p "9000:9000" \
 	--name reverse-proxy \
 	--network montagu_proxy\
 	$SHA_TAG 443 localhost

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -12,20 +12,6 @@ function cleanup() {
 
 trap cleanup EXIT
 
-# We need to have an orderly demo folder available for outpack_server container to become available - see README for
-# suggestion for local setup. If we're on Buildkit, write out a minimal config and the server should spin up
-#if [[ "$BUILDKITE" = "true" ]]; then
-#    OUTPACK_ROOT=$HERE/../../packit/demos/orderly/.outpack
-#    OUTPACK_CONFIG_FILE=$OUTPACK_ROOT/config.json
-#    if [ ! -f $OUTPACK_CONFIG_FILE ]; then
-#        echo "Testing local mkdir"
-#        mkdir -p $HERE/testdir || true
-#        echo "Creating outpack config file"
-#        mkdir -p $OUTPACK_ROOT || true
-#        echo '{"core":{"path_archive":null,"use_file_store":true,"require_complete_tree":true,"hash_algorithm":"sha256"},"location":[{"name":"local","type":"local","args":{}}]}' > $OUTPACK_CONFIG_FILE || true
-#    fi
-#fi
-
 mkdir montagu_emails
 $HERE/run-dependencies.sh
 
@@ -44,11 +30,6 @@ docker run -d \
   --restart always \
   nginx/nginx-prometheus-exporter:0.2.0 \
   -nginx.scrape-uri "http://reverse-proxy/basic_status"
-
-#TODO: remove debug
-docker ps
-docker logs montagu-outpack_server-1
-docker exec reverse-proxy curl http://outpack_server:8000/metrics
 
 docker run \
   --rm \

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -18,6 +18,8 @@ if [[ "$BUILDKITE" = "true" ]]; then
     OUTPACK_ROOT=$HERE/../../packit/demos/orderly/.outpack
     OUTPACK_CONFIG_FILE=$OUTPACK_ROOT/config.json
     if [ ! -f $OUTPACK_CONFIG_FILE ]; then
+        echo "Testing local mkdir"
+        mkdir -p $HERE/testdir || true
         echo "Creating outpack config file"
         mkdir -p $OUTPACK_ROOT || true
         echo '{"core":{"path_archive":null,"use_file_store":true,"require_complete_tree":true,"hash_algorithm":"sha256"},"location":[{"name":"local","type":"local","args":{}}]}' > $OUTPACK_CONFIG_FILE || true

--- a/tests/integration_tests/metrics.itest.js
+++ b/tests/integration_tests/metrics.itest.js
@@ -1,0 +1,12 @@
+const TestHelper = require("./test-helper");
+test("can access packit api metrics", async () => {
+    const response = await TestHelper.apiFetch(`/packit-api/metrics`, {});
+    expect(response.status).toBe(200);
+    expect(await response.text()).toMatch(/jvm_info/);
+});
+
+test("can access outpack server metrics", async () => {
+    const response = await TestHelper.apiFetch(`/outpack_server/metrics`, {});
+    expect(response.status).toBe(200);
+    expect(await response.text()).toMatch(/http_requests_duration_seconds_bucket/);
+});

--- a/tests/integration_tests/metrics.itest.js
+++ b/tests/integration_tests/metrics.itest.js
@@ -1,12 +1,13 @@
 const TestHelper = require("./test-helper");
+
 test("can access packit api metrics", async () => {
-    const response = await TestHelper.apiFetch(`/packit-api/metrics`, {});
+    const response = await TestHelper.metricsFetch("/metrics/packit-api");
     expect(response.status).toBe(200);
     expect(await response.text()).toMatch(/jvm_info/);
 });
 
 test("can access outpack server metrics", async () => {
-    const response = await TestHelper.apiFetch(`/outpack_server/metrics`, {});
+    const response = await TestHelper.metricsFetch("/metrics/outpack_server");
     expect(response.status).toBe(200);
     expect(await response.text()).toMatch(/http_requests_duration_seconds_bucket/);
 });

--- a/tests/integration_tests/test-helper.js
+++ b/tests/integration_tests/test-helper.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const fetch = require('cross-fetch');
 const https = require('https');
+const http = require('http');
 
 const emailsDir = path.resolve(__dirname, "../../montagu_emails");
 
@@ -104,6 +105,13 @@ const TestHelper = {
         });
         return await fetch(`https://localhost${url}`, {
             headers,
+            agent
+        });
+    },
+
+    metricsFetch: async function (url) {
+        const agent = new http.Agent();
+        return await fetch(`http://localhost:9000${url}`, {
             agent
         });
     }


### PR DESCRIPTION
This branch configures the montagu proxy to make the prometheus metrics endpoints available for both packit api and outpack server, so that we can use them in the monitor. 

It uses the default packit api management port (I think it would be a faff to template the nginx config to make this configurable, and shouldn't be necessary). 

I've used public endpoints which I think mirror the ones provided by the nix configs, including the mix of `-` and `_` i.e. `/packit-api/metrics` and `/outpack_server/metrics` but let me know if you think something else would be better!

Adding an integration test for this revealed a pre-existing issue with running the deps on Buildkite, which is that the outpack server container wasn't starting up properly due to the outpack root not existing. Have added a barebones root for buildkite to use. 